### PR TITLE
New STSE handler initialization + MISRA + clear session context

### DIFF
--- a/api/stse_data_storage.c
+++ b/api/stse_data_storage.c
@@ -17,6 +17,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 
+#include <string.h>
 #include <api/stse_data_storage.h>
 
 stse_ReturnCode_t stse_data_storage_get_total_partition_count(
@@ -76,12 +77,8 @@ stse_ReturnCode_t stse_data_storage_read_zone(
 			chunck_length = remaning_length;
 		}
 
-		stsafea_read_option_t stsafea_read_option = { \
-                                    .new_read_ac = (stsafea_ac_t)0, \
-                                    .new_read_ac_change_right = (stsafea_ac_change_right_t)0, \
-                                    .change_ac_indicator = (stsafea_zone_ac_change_indicator_t) 0, \
-                                    .filler = 0 \
-                                    };
+		stsafea_read_option_t stsafea_read_option;
+		memset(&stsafea_read_option, 0, sizeof(stsafea_read_option));
 
 		/*- Transfer command/response */
 		ret = stsafea_read_data_zone(

--- a/api/stse_data_storage.c
+++ b/api/stse_data_storage.c
@@ -125,10 +125,10 @@ stse_ReturnCode_t stse_data_storage_update_zone(
 	stsafea_update_option_t options;
 
 	options.atomicity = atomicity;
-	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)0 ;
+	options.change_ac_indicator = AC_MOD_CHANGE;
 	options.filler = 0;
-	options.new_update_ac = (stsafea_ac_t)0;
-	options.new_update_ac_change_right = (stsafea_ac_change_right_t)0;
+	options.new_update_ac = STSAFEA_AC_ALWAYS;
+	options.new_update_ac_change_right = STSAFE_ACCR_DISABLED;
 
 	/* - Check STSAFE handler initialization */
 	if (pSTSE == NULL)
@@ -163,10 +163,10 @@ stse_ReturnCode_t stse_data_storage_decrement_counter(
 ){
 	stsafea_decrement_option_t options;
 
-	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)0 ;
+	options.change_ac_indicator = AC_MOD_CHANGE;
 	options.filler = 0;
-	options.new_decrement_ac = (stsafea_ac_t)0;
-	options.new_decrement_ac_change_right = (stsafea_ac_change_right_t)0;
+	options.new_decrement_ac = STSAFEA_AC_ALWAYS;
+	options.new_decrement_ac_change_right = STSAFE_ACCR_DISABLED;
 
 	/* - Check STSAFE handler initialization */
 	if (pSTSE == NULL)
@@ -202,10 +202,10 @@ stse_ReturnCode_t stse_data_storage_read_counter(
 	PLAT_UI16 chunck_length = 0;
 	PLAT_UI16 chunck_offset = offset;
 
-	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)0 ;
+	options.change_ac_indicator = AC_MOD_CHANGE;
 	options.filler = 0;
-	options.new_read_ac = (stsafea_ac_t)0;
-	options.new_read_ac_change_right = (stsafea_ac_change_right_t)0;
+	options.new_read_ac = STSAFEA_AC_ALWAYS;
+	options.new_read_ac_change_right = STSAFE_ACCR_DISABLED;
 
 
 	/*- Perform read by chunk */
@@ -267,7 +267,7 @@ stse_ReturnCode_t stse_data_storage_change_read_access_condition(
 
 	stsafea_read_option_t options;
 
-	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)1;
+	options.change_ac_indicator = AC_MOD_IGNORE;
 	options.filler = 0;
 	options.new_read_ac = ac;
 	options.new_read_ac_change_right = ac_change_right;
@@ -302,7 +302,7 @@ stse_ReturnCode_t stse_data_storage_change_update_access_condition(stse_Handler_
 	stsafea_update_option_t options;
 
 	/*- Prepare update options */
-	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)1;
+	options.change_ac_indicator = AC_MOD_IGNORE;
 	options.filler = 0;
 	options.new_update_ac = ac;
 	options.new_update_ac_change_right = ac_change_right;
@@ -335,7 +335,7 @@ stse_ReturnCode_t stse_data_storage_change_decrement_access_condition(stse_Handl
 ){
 	stsafea_decrement_option_t options;
 
-	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)1;
+	options.change_ac_indicator = AC_MOD_IGNORE;
 	options.filler = 0;
 	options.new_decrement_ac = ac;
 	options.new_decrement_ac_change_right = ac_change_right;

--- a/api/stse_data_storage.c
+++ b/api/stse_data_storage.c
@@ -53,10 +53,10 @@ stse_ReturnCode_t stse_data_storage_read_zone(
 		stsafea_cmd_protection_t protection
 		)
 {
-	volatile stse_ReturnCode_t ret = STSE_API_INVALID_PARAMETER;
-	volatile PLAT_UI16 remaning_length = length;
-	volatile PLAT_UI16 chunck_length = 0;
-	volatile PLAT_UI16 chunck_offset = offset;
+	stse_ReturnCode_t ret = STSE_API_INVALID_PARAMETER;
+	PLAT_UI16 remaning_length = length;
+	PLAT_UI16 chunck_length = 0;
+	PLAT_UI16 chunck_offset = offset;
 
 	/* - Check STSAFE handler initialization */
 	if (pSTSE == NULL)
@@ -76,11 +76,18 @@ stse_ReturnCode_t stse_data_storage_read_zone(
 			chunck_length = remaning_length;
 		}
 
+		stsafea_read_option_t stsafea_read_option = { \
+                                    .new_read_ac = (stsafea_ac_t)0, \
+                                    .new_read_ac_change_right = (stsafea_ac_change_right_t)0, \
+                                    .change_ac_indicator = (stsafea_zone_ac_change_indicator_t) 0, \
+                                    .filler = 0 \
+                                    };
+
 		/*- Transfer command/response */
 		ret = stsafea_read_data_zone(
 				pSTSE,
 				zone,
-				(stsafea_read_option_t){0},
+				stsafea_read_option,
 				chunck_offset,
 				pBuffer + (chunck_offset)-offset,
 				chunck_length,
@@ -118,10 +125,10 @@ stse_ReturnCode_t stse_data_storage_update_zone(
 	stsafea_update_option_t options;
 
 	options.atomicity = atomicity;
-	options.change_ac_indicator = 0 ;
+	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)0 ;
 	options.filler = 0;
-	options.new_update_ac = 0;
-	options.new_update_ac_change_right = 0;
+	options.new_update_ac = (stsafea_ac_t)0;
+	options.new_update_ac_change_right = (stsafea_ac_change_right_t)0;
 
 	/* - Check STSAFE handler initialization */
 	if (pSTSE == NULL)
@@ -156,10 +163,10 @@ stse_ReturnCode_t stse_data_storage_decrement_counter(
 ){
 	stsafea_decrement_option_t options;
 
-	options.change_ac_indicator = 0 ;
+	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)0 ;
 	options.filler = 0;
-	options.new_decrement_ac = 0;
-	options.new_decrement_ac_change_right = 0;
+	options.new_decrement_ac = (stsafea_ac_t)0;
+	options.new_decrement_ac_change_right = (stsafea_ac_change_right_t)0;
 
 	/* - Check STSAFE handler initialization */
 	if (pSTSE == NULL)
@@ -190,15 +197,15 @@ stse_ReturnCode_t stse_data_storage_read_counter(
 		stsafea_cmd_protection_t protection
 ){
 	stsafea_read_option_t options;
-	volatile stse_ReturnCode_t ret = STSE_API_INVALID_PARAMETER;
-	volatile PLAT_UI16 remaning_length = length;
-	volatile PLAT_UI16 chunck_length = 0;
-	volatile PLAT_UI16 chunck_offset = offset;
+	stse_ReturnCode_t ret = STSE_API_INVALID_PARAMETER;
+	PLAT_UI16 remaning_length = length;
+	PLAT_UI16 chunck_length = 0;
+	PLAT_UI16 chunck_offset = offset;
 
-	options.change_ac_indicator = 0 ;
+	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)0 ;
 	options.filler = 0;
-	options.new_read_ac = 0;
-	options.new_read_ac_change_right = 0;
+	options.new_read_ac = (stsafea_ac_t)0;
+	options.new_read_ac_change_right = (stsafea_ac_change_right_t)0;
 
 
 	/*- Perform read by chunk */
@@ -260,7 +267,7 @@ stse_ReturnCode_t stse_data_storage_change_read_access_condition(
 
 	stsafea_read_option_t options;
 
-	options.change_ac_indicator = 1;
+	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)1;
 	options.filler = 0;
 	options.new_read_ac = ac;
 	options.new_read_ac_change_right = ac_change_right;
@@ -295,7 +302,7 @@ stse_ReturnCode_t stse_data_storage_change_update_access_condition(stse_Handler_
 	stsafea_update_option_t options;
 
 	/*- Prepare update options */
-	options.change_ac_indicator = 1;
+	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)1;
 	options.filler = 0;
 	options.new_update_ac = ac;
 	options.new_update_ac_change_right = ac_change_right;
@@ -328,7 +335,7 @@ stse_ReturnCode_t stse_data_storage_change_decrement_access_condition(stse_Handl
 ){
 	stsafea_decrement_option_t options;
 
-	options.change_ac_indicator = 1;
+	options.change_ac_indicator = (stsafea_zone_ac_change_indicator_t)1;
 	options.filler = 0;
 	options.new_decrement_ac = ac;
 	options.new_decrement_ac_change_right = ac_change_right;

--- a/api/stse_symmetric_keys_management.c
+++ b/api/stse_symmetric_keys_management.c
@@ -104,7 +104,7 @@ static stse_ReturnCode_t stse_start_volatile_KEK_session(
 		memset(stsafe_ecdhe_public_key, 0, pub_key_size);
 		memset(host_ecdhe_public_key, 0, pub_key_size);
 		memset(host_ecdhe_private_key, 0, priv_key_size);
-		stsafea_session_erase_context(pSession);
+		stsafea_session_clear_context(pSession);
 		return( ret );
 	}
 
@@ -120,7 +120,7 @@ static stse_ReturnCode_t stse_start_volatile_KEK_session(
 	{
 		memset(stsafe_ecdhe_public_key, 0, pub_key_size);
 		memset(host_ecdhe_public_key, 0, pub_key_size);
-		stsafea_session_erase_context(pSession);
+		stsafea_session_clear_context(pSession);
 		return( STSE_UNEXPECTED_ERROR );
 	}
 
@@ -147,7 +147,7 @@ static stse_ReturnCode_t stse_start_volatile_KEK_session(
 
 	if(ret != STSE_OK)
 	{
-		stsafea_session_erase_context(pSession);
+		stsafea_session_clear_context(pSession);
 		return( STSE_UNEXPECTED_ERROR );
 	}
 
@@ -303,7 +303,7 @@ static stse_ReturnCode_t stse_start_volatile_KEK_session_authenticated(
 		memset(host_ecdhe_public_key, 0, pub_key_size);
 		memset(host_ecdhe_private_key, 0, ecdhe_priv_key_size);
 		memset(pTBS, 0, tbs_length);
-		stsafea_session_erase_context(pSession);
+		stsafea_session_clear_context(pSession);
 		return( ret );
 	}
 
@@ -322,7 +322,7 @@ static stse_ReturnCode_t stse_start_volatile_KEK_session_authenticated(
 		memset(stsafe_ecdhe_public_key, 0, pub_key_size);
 		memset(host_ecdhe_public_key, 0, pub_key_size);
 		memset(host_ecdhe_private_key, 0, ecdhe_priv_key_size);
-		stsafea_session_erase_context(pSession);
+		stsafea_session_clear_context(pSession);
 		return( ret );
 	}
 
@@ -337,7 +337,7 @@ static stse_ReturnCode_t stse_start_volatile_KEK_session_authenticated(
 	{
 		memset(stsafe_ecdhe_public_key, 0, pub_key_size);
 		memset(host_ecdhe_public_key, 0, pub_key_size);
-		stsafea_session_erase_context(pSession);
+		stsafea_session_clear_context(pSession);
 		return( STSE_UNEXPECTED_ERROR );
 	}
 
@@ -366,7 +366,7 @@ static stse_ReturnCode_t stse_start_volatile_KEK_session_authenticated(
 
 	if(ret != STSE_OK)
 	{
-		stsafea_session_erase_context(pSession);
+		stsafea_session_clear_context(pSession);
 		return( STSE_UNEXPECTED_ERROR );
 	}
 
@@ -387,7 +387,7 @@ static stse_ReturnCode_t stse_stop_volatile_KEK_session( stse_Handler_t *pSTSE ,
 	}
 
 	/* - Clear KEK session context on local host */
-	stsafea_session_erase_context(pSession);
+	stsafea_session_clear_context(pSession);
 
 	/* - Clear KEK session context in target SE */
 	ret = stsafea_stop_volatile_KEK_session(pSTSE);
@@ -551,12 +551,13 @@ stse_ReturnCode_t stse_host_key_provisioning_wrapped (
 	PLAT_UI8 host_key_envelope[host_keys_envelope_length];
 
 
-	stsafea_session_handler_allocate(volatile_KEK_sesion);
+	stsafea_session_handler_allocate(volatile_KEK_session);
+	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start volatile KEK  */
 	ret = stse_start_volatile_KEK_session(
 			pSTSE,
-			&volatile_KEK_sesion,
+			&volatile_KEK_session,
 			ecdhe_ecc_key_type);
 
 	if(ret != STSE_OK)
@@ -581,7 +582,7 @@ stse_ReturnCode_t stse_host_key_provisioning_wrapped (
 	/* - Wrap */
 	ret = stse_KEK_wrap(
 			pSTSE,
-			&volatile_KEK_sesion,
+			&volatile_KEK_session,
 			host_key_envelope,
 			( host_keys_envelope_length - STSAFEA_HOST_KEY_WRAPPING_AUTHENTICATION_TAG_LENGTH ),
 			host_key_envelope,
@@ -644,12 +645,13 @@ stse_ReturnCode_t stse_host_key_provisioning_wrapped_authenticated (
 
 	PLAT_UI8 host_key_envelope[host_keys_envelope_length];
 
-	stsafea_session_handler_allocate(volatile_KEK_sesion);
+	stsafea_session_handler_allocate(volatile_KEK_session);
+	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start volatile KEK Authenticated */
 	ret = stse_start_volatile_KEK_session_authenticated(
 			pSTSE,
-			&volatile_KEK_sesion,
+			&volatile_KEK_session,
 			ecdhe_ecc_key_type,
 			signature_public_key_slot_number,
 			signature_hash_algo,
@@ -677,7 +679,7 @@ stse_ReturnCode_t stse_host_key_provisioning_wrapped_authenticated (
 	/* - Wrap */
 	ret = stse_KEK_wrap(
 			pSTSE,
-			&volatile_KEK_sesion,
+			&volatile_KEK_session,
 			host_key_envelope,
 			( host_keys_envelope_length - STSAFEA_HOST_KEY_WRAPPING_AUTHENTICATION_TAG_LENGTH ),
 			host_key_envelope,
@@ -700,7 +702,7 @@ stse_ReturnCode_t stse_host_key_provisioning_wrapped_authenticated (
 	}
 
 	/* - Stop volatile KEK */
-	ret = stse_stop_volatile_KEK_session(pSTSE,&volatile_KEK_sesion);
+	ret = stse_stop_volatile_KEK_session(pSTSE,&volatile_KEK_session);
 
 	return ret;
 }
@@ -821,17 +823,18 @@ stse_ReturnCode_t stse_write_symmetric_key_wrapped(
 		return( STSE_API_HANDLER_NOT_INITIALISED );
 	}
 
-	stsafea_session_handler_allocate(volatile_KEK_sesion);
+	stsafea_session_handler_allocate(volatile_KEK_session);
+	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start Volatile KEK session */
-	ret = stse_start_volatile_KEK_session(pSTSE, &volatile_KEK_sesion,kek_session_ecc_type);
+	ret = stse_start_volatile_KEK_session(pSTSE, &volatile_KEK_session,kek_session_ecc_type);
 	if(ret != STSE_OK)
 	{
 		return( ret );
 	}
 
 	/* - Format envelope to wrap */
-	PLAT_UI8 envelope_key_length =  key_info->type == STSAFEA_SYMMETRIC_KEY_TYPE_AES_256 ? STSAFEA_AES_256_KEY_SIZE : STSAFEA_AES_128_KEY_SIZE;
+	PLAT_UI8 envelope_key_length = key_info->type == STSAFEA_SYMMETRIC_KEY_TYPE_AES_256 ? STSAFEA_AES_256_KEY_SIZE : STSAFEA_AES_128_KEY_SIZE;
 	PLAT_UI8 envelope_length = envelope_key_length + key_info->info_length;
 	PLAT_UI8 envelope_padding_length = 8 - (envelope_length % 8);
 
@@ -851,7 +854,7 @@ stse_ReturnCode_t stse_write_symmetric_key_wrapped(
 	/* - Wrap the envelope */
 	ret = stse_KEK_wrap(
 			pSTSE,
-			&volatile_KEK_sesion,
+			&volatile_KEK_session,
 			envelope,
 			envelope_length,
 			envelope,
@@ -874,7 +877,7 @@ stse_ReturnCode_t stse_write_symmetric_key_wrapped(
 	}
 
 	/* - Close Volatile KEK session */
-	ret = stse_stop_volatile_KEK_session(pSTSE,&volatile_KEK_sesion);
+	ret = stse_stop_volatile_KEK_session(pSTSE,&volatile_KEK_session);
 
 	return ret;
 }
@@ -903,6 +906,7 @@ stse_ReturnCode_t stse_write_symmetric_key_wrapped_authenticated (
 	}
 
 	stsafea_session_handler_allocate(volatile_KEK_session);
+	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start volatile KEK Authenticated */
 	ret = stse_start_volatile_KEK_session_authenticated(

--- a/certificate/stse_certificate_prints.c
+++ b/certificate/stse_certificate_prints.c
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 #include "certificate/stse_certificate_prints.h"
 #include "certificate/stse_certificate_subparsing.h"
 
@@ -248,7 +249,7 @@ void stse_certificate_print_parsed_cert(stse_certificate_t *stse_certificate)
   //printf("Fields: %08X\n", stse_certificate->fields);
   //printFields(stse_certificate->fields);
 
-  printf("\n\r\t x509 Version: %ld", (long)stse_certificate->x509Version + 1);
+  printf("\n\r\t x509 Version: %" PRId32, stse_certificate->x509Version + 1);
   if (stse_certificate->serialNumber != NULL && stse_certificate->serialNumberSize > 0)
     print_buffer("\n\r\tSerialNumber: ", stse_certificate->serialNumber, stse_certificate->serialNumberSize);
   if (stse_certificate->issuer != NULL && stse_certificate->issuerSize > 0)

--- a/certificate/stse_certificate_prints.c
+++ b/certificate/stse_certificate_prints.c
@@ -248,7 +248,7 @@ void stse_certificate_print_parsed_cert(stse_certificate_t *stse_certificate)
   //printf("Fields: %08X\n", stse_certificate->fields);
   //printFields(stse_certificate->fields);
 
-  printf("\n\r\t x509 Version: %ld", stse_certificate->x509Version + 1);
+  printf("\n\r\t x509 Version: %ld", (long)stse_certificate->x509Version + 1);
   if (stse_certificate->serialNumber != NULL && stse_certificate->serialNumberSize > 0)
     print_buffer("\n\r\tSerialNumber: ", stse_certificate->serialNumber, stse_certificate->serialNumberSize);
   if (stse_certificate->issuer != NULL && stse_certificate->issuerSize > 0)
@@ -345,8 +345,8 @@ void stse_certificate_print_validity(const PLAT_UI8 *validity)
   const PLAT_UI8 *next;
   stse_certificate_parse_validity(validity, &notBefore_st, &notAfter_st, &next);
   printf("\n\r\t Validity:");
-  printf("\n\r\t\t Not Before: %04ld-%02d-%02d %02d:%02d:%02d", notBefore_st.year, notBefore_st.month, notBefore_st.days, notBefore_st.hours, notBefore_st.minutes, notBefore_st.seconds);
-  printf("\n\r\t\t Not After:  %04ld-%02d-%02d %02d:%02d:%02d", notAfter_st.year, notAfter_st.month, notAfter_st.days, notAfter_st.hours, notAfter_st.minutes, notAfter_st.seconds);
+  printf("\n\r\t\t Not Before: %04ld-%02d-%02d %02d:%02d:%02d", (long)notBefore_st.year, notBefore_st.month, notBefore_st.days, notBefore_st.hours, notBefore_st.minutes, notBefore_st.seconds);
+  printf("\n\r\t\t Not After:  %04ld-%02d-%02d %02d:%02d:%02d", (long)notAfter_st.year, notAfter_st.month, notAfter_st.days, notAfter_st.hours, notAfter_st.minutes, notAfter_st.seconds);
 }
 
 static void printExtensions(PLAT_UI32 extensionsFlags)
@@ -369,7 +369,7 @@ static void printExtensions(PLAT_UI32 extensionsFlags)
     }
     if (((extensionsFlags >> 3) & 1) == 1)
     {
-      printf("PathSize: %ld", (extensionsFlags >> 4) & 15);
+      printf("PathSize: %ld", (long)(extensionsFlags >> 4) & 15);
     }
   }
   if (((extensionsFlags >> 8) & 1) == 1)

--- a/certificate/stse_certificate_prints.c
+++ b/certificate/stse_certificate_prints.c
@@ -346,8 +346,8 @@ void stse_certificate_print_validity(const PLAT_UI8 *validity)
   const PLAT_UI8 *next;
   stse_certificate_parse_validity(validity, &notBefore_st, &notAfter_st, &next);
   printf("\n\r\t Validity:");
-  printf("\n\r\t\t Not Before: %04ld-%02d-%02d %02d:%02d:%02d", (long)notBefore_st.year, notBefore_st.month, notBefore_st.days, notBefore_st.hours, notBefore_st.minutes, notBefore_st.seconds);
-  printf("\n\r\t\t Not After:  %04ld-%02d-%02d %02d:%02d:%02d", (long)notAfter_st.year, notAfter_st.month, notAfter_st.days, notAfter_st.hours, notAfter_st.minutes, notAfter_st.seconds);
+  printf("\n\r\t\t Not Before: %04" PRId32 "-%02d-%02d %02d:%02d:%02d", notBefore_st.year, notBefore_st.month, notBefore_st.days, notBefore_st.hours, notBefore_st.minutes, notBefore_st.seconds);
+  printf("\n\r\t\t Not After:  %04" PRId32 "-%02d-%02d %02d:%02d:%02d", notAfter_st.year, notAfter_st.month, notAfter_st.days, notAfter_st.hours, notAfter_st.minutes, notAfter_st.seconds);
 }
 
 static void printExtensions(PLAT_UI32 extensionsFlags)
@@ -370,7 +370,7 @@ static void printExtensions(PLAT_UI32 extensionsFlags)
     }
     if (((extensionsFlags >> 3) & 1) == 1)
     {
-      printf("PathSize: %ld", (long)(extensionsFlags >> 4) & 15);
+      printf("PathSize: %" PRId32, (extensionsFlags >> 4) & 15);
     }
   }
   if (((extensionsFlags >> 8) & 1) == 1)

--- a/core/stse_device.c
+++ b/core/stse_device.c
@@ -1,0 +1,51 @@
+/*!
+ * ******************************************************************************
+ * \file	stse_device.c
+ * \brief   STSAFE Frame layer (sources)
+ * \author  STMicroelectronics - CS application team
+ *
+ ******************************************************************************
+ * \attention
+ *
+ * <h2><center>&copy; COPYRIGHT 2022 STMicroelectronics</center></h2>
+ *
+ * This software is licensed under terms that can be found in the LICENSE file in
+ * the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
+
+#include "core/stse_device.h"
+#include "core/stse_platform.h"
+
+
+stse_ReturnCode_t stse_set_default_handler_value(stse_Handler_t *pStseHandler)
+{
+  if (pStseHandler == NULL)
+  {
+    return STSE_CORE_HANDLER_NOT_INITIALISED;
+  }
+  
+  pStseHandler->device_type = (stse_device_t)0;
+  pStseHandler->pPerso_info = NULL;
+  pStseHandler->pActive_host_session = NULL;
+  pStseHandler->pActive_other_session = NULL;
+  pStseHandler->io.BusRecvStart = stse_platform_i2c_receive_start;
+  pStseHandler->io.BusRecvContinue = stse_platform_i2c_receive_continue;
+  pStseHandler->io.BusRecvStop = stse_platform_i2c_receive_stop;
+  pStseHandler->io.BusSendStart = stse_platform_i2c_send_start;
+  pStseHandler->io.BusSendContinue = stse_platform_i2c_send_continue;
+  pStseHandler->io.BusSendStop = stse_platform_i2c_send_stop;
+  pStseHandler->io.IOLineGet = NULL;
+  pStseHandler->io.BusWake = stse_platform_i2c_wake;
+  pStseHandler->io.BusRecovery = NULL;
+  pStseHandler->io.PowerLineOff = stse_platform_power_off;
+  pStseHandler->io.PowerLineOn = stse_platform_power_on;
+  pStseHandler->io.Busaddr = 0;
+  pStseHandler->io.Devaddr = 0x20;
+  pStseHandler->io.BusSpeed = 100;
+  pStseHandler->io.BusType = STSE_BUS_TYPE_I2C;
+  
+  return STSE_OK;
+}

--- a/core/stse_device.h
+++ b/core/stse_device.h
@@ -82,44 +82,44 @@ typedef enum stse_bus {
 typedef struct
 	{
 		stse_ReturnCode_t (* BusRecvStart) (
-				PLAT_UI8,  /* busID */
-				PLAT_UI8,  /* devAddr */
-				PLAT_UI8,  /* speed */
-				PLAT_UI16 * /* pFrameLength */
+				PLAT_UI8,	/* busID */
+				PLAT_UI8,	/* devAddr */
+				PLAT_UI16,	/* speed */
+				PLAT_UI16 *	/* pFrameLength */
 		); /*\var stse_io_t::BusRecvStart Bus Receive start function callback */
 		stse_ReturnCode_t (* BusRecvContinue) (
-				PLAT_UI8, /*busID*/
-				PLAT_UI8, /*devAddr*/
-				PLAT_UI8, /*speed*/
-				PLAT_UI8 *,/*pElement*/
-				PLAT_UI16 /*element_size*/
+				PLAT_UI8,	/*busID*/
+				PLAT_UI8,	/*devAddr*/
+				PLAT_UI16,	/*speed*/
+				PLAT_UI8 *,	/*pElement*/
+				PLAT_UI16	/*element_size*/
 		); /*<\var stse_io_t::BusRecvContinue Bus Receive continue function callback */
 		stse_ReturnCode_t (* BusRecvStop) (
-				PLAT_UI8, /*busID*/
-				PLAT_UI8, /*devAddr*/
-				PLAT_UI8, /*speed*/
-				PLAT_UI8 *,/*pElement*/
-				PLAT_UI16 /*element_size*/
+				PLAT_UI8,	/*busID*/
+				PLAT_UI8,	/*devAddr*/
+				PLAT_UI16,	/*speed*/
+				PLAT_UI8 *,	/*pElement*/
+				PLAT_UI16	/*element_size*/
 		); /*<\var stse_io_t::BusRecvStop Bus Receive stop function callback */
 		stse_ReturnCode_t (* BusSendStart)(
-				PLAT_UI8, /* busID */
-				PLAT_UI8, /* devAddr */
-				PLAT_UI8, /* speed */
-				PLAT_UI16 /* FrameLength */
+				PLAT_UI8,	/* busID */
+				PLAT_UI8,	/* devAddr */
+				PLAT_UI16,	/* speed */
+				PLAT_UI16	/* FrameLength */
 		); /*<\var stse_io_t::BusSendStart Bus Send start function callback */
 		stse_ReturnCode_t (* BusSendContinue)(
-				PLAT_UI8, /*busID*/
-				PLAT_UI8, /*devAddr*/
-				PLAT_UI8, /*speed*/
-				PLAT_UI8 *,/*pElement*/
-				PLAT_UI16 /*element_size*/
+				PLAT_UI8,	/*busID*/
+				PLAT_UI8,	/*devAddr*/
+				PLAT_UI16,	/*speed*/
+				PLAT_UI8 *,	/*pElement*/
+				PLAT_UI16	/*element_size*/
 		); /*<\var stse_io_t::BusSendContinue Bus Send continue function callback */
 		stse_ReturnCode_t (* BusSendStop)(
-				PLAT_UI8, /*busID*/
-				PLAT_UI8, /*devAddr*/
-				PLAT_UI8, /*speed*/
-				PLAT_UI8 *,/*pElement*/
-				PLAT_UI16 /*element_size*/
+				PLAT_UI8,	/*busID*/
+				PLAT_UI8,	/*devAddr*/
+				PLAT_UI16,	/*speed*/
+				PLAT_UI8 *,	/*pElement*/
+				PLAT_UI16	/*element_size*/
 		); /*<\var stse_io_t::BusSendStop Bus Send stop function callback */
 		stse_ReturnCode_t (* IOLineGet)(
 				PLAT_UI8
@@ -127,7 +127,7 @@ typedef struct
 		stse_ReturnCode_t (* BusWake)(
 				PLAT_UI8,
 				PLAT_UI8,
-				PLAT_UI8
+				PLAT_UI16
 		); /*<\var stse_io_t::BusWake Bus wake function callback */
 		stse_ReturnCode_t (* BusRecovery)(
 				PLAT_UI8,
@@ -143,7 +143,7 @@ typedef struct
 		); /*<\var stse_io_t::PowerLineOn Bus power line on function callback */
 		PLAT_UI8 Busaddr;				/*<\var stse_io_t::Busaddr Bus Address */
 		PLAT_UI8 Devaddr;				/*<\var stse_io_t::Devaddr Device address */
-		PLAT_UI8 BusSpeed;				/*<\var stse_io_t::BusSpeed Bus speed */
+		PLAT_UI16 BusSpeed;				/*<\var stse_io_t::BusSpeed Bus speed */
 		stse_bus_t BusType;				/*<\var stse_io_t::BusType Bus type */
 	} PLAT_PACKED_STRUCT stse_io_t;
 

--- a/core/stse_device.h
+++ b/core/stse_device.h
@@ -81,7 +81,7 @@ typedef enum stse_bus {
  */
 typedef struct
 	{
-		PLAT_UI16 (* BusRecvStart) (
+		stse_ReturnCode_t (* BusRecvStart) (
 				PLAT_UI8,  /* busID */
 				PLAT_UI8,  /* devAddr */
 				PLAT_UI8,  /* speed */

--- a/core/stse_device.h
+++ b/core/stse_device.h
@@ -47,30 +47,6 @@ typedef enum
 }stse_session_type_t;
 
 
-#define stse_allocate_handler(x) stse_Handler_t x = {\
-			.device_type = 0,\
-			.pPerso_info = NULL,\
-			.pActive_host_session = NULL,\
-			.pActive_other_session = NULL,\
-			.io = {\
-					.BusRecvStart = stse_platform_i2c_receive_start,\
-					.BusRecvContinue = stse_platform_i2c_receive_continue,\
-					.BusRecvStop = stse_platform_i2c_receive_stop,\
-					.BusSendStart = stse_platform_i2c_send_start,\
-					.BusSendContinue = stse_platform_i2c_send_continue,\
-					.BusSendStop = stse_platform_i2c_send_stop,\
-					.IOLineGet = NULL,\
-					.BusWake = stse_platform_i2c_wake,\
-					.BusRecovery = NULL,\
-					.PowerLineOff = stse_platform_power_off,\
-					.PowerLineOn = stse_platform_power_on,\
-					.Busaddr = 0,\
-					.Devaddr = 0x20,\
-					.BusSpeed = 100,\
-					.BusType = STSE_BUS_TYPE_I2C,\
-				} \
-}
-
 /*
  * \details STMicroelectronics Secure Element device type
  */
@@ -217,6 +193,14 @@ struct stse_Handler_t {
 /* Exported variables --------------------------------------------------------*/
 
 extern stse_perso_info_t dynamic_product_perso;
+
+/**
+ * \brief 		Initialise the STSE handler to default value
+ * \details 		This core function initialise the handler to default value
+ * \param[in] 		pStseHandler 	Pointer to STSE handler
+ * \return \ref stsafe_ReturnCode_t : STSAFE_OK on success ; error code otherwise
+ */
+stse_ReturnCode_t stse_set_default_handler_value(stse_Handler_t *pStseHandler);
 
 /*! @}*/
 

--- a/core/stse_frame.c
+++ b/core/stse_frame.c
@@ -202,8 +202,8 @@ stse_ReturnCode_t stse_frame_transmit(stse_Handler_t* pSTSE, stse_frame_t* pFram
 {
     stse_ReturnCode_t ret = STSE_PLATFORM_BUS_ACK_ERROR;
     PLAT_UI16 retry_count = STSE_MAX_POLLING_RETRY;
-    volatile stse_frame_element_t *pCurrent_element;
-    volatile PLAT_UI16 crc_ret;
+    stse_frame_element_t *pCurrent_element;
+    PLAT_UI16 crc_ret;
     PLAT_UI8 crc[STSE_FRAME_CRC_SIZE] = {0};
 
     /*- Verify Parameters */
@@ -228,6 +228,7 @@ stse_ReturnCode_t stse_frame_transmit(stse_Handler_t* pSTSE, stse_frame_t* pFram
 #ifdef STSAFE_FRAME_DEBUG_LOG
 	printf("\n\r STSAFE Frame > ");
 	stse_frame_debug_print(pFrame);
+	printf("\n\r");
 #endif
     while ((retry_count != 0) && (ret == STSE_PLATFORM_BUS_ACK_ERROR))
     {
@@ -298,7 +299,7 @@ stse_ReturnCode_t stse_frame_receive(stse_Handler_t* pSTSE, stse_frame_t* pFrame
     while ((retry_count != 0) && (ret == STSE_PLATFORM_BUS_ACK_ERROR))
     {
 		/* - Receive frame length from target STSAFE */
-		ret = pSTSE->io.BusRecvStart(
+		ret = (stse_ReturnCode_t)pSTSE->io.BusRecvStart(
 				pSTSE->io.Busaddr,
 				pSTSE->io.Devaddr,
 				pSTSE->io.BusSpeed,
@@ -360,6 +361,7 @@ stse_ReturnCode_t stse_frame_receive(stse_Handler_t* pSTSE, stse_frame_t* pFrame
 #ifdef STSAFE_FRAME_DEBUG_LOG
     printf("\n\r STSAFE Frame < ");
     stse_frame_debug_print(pFrame);
+    printf("\n\r");
 #endif
 
     /* - swap CRC */

--- a/core/stse_frame.c
+++ b/core/stse_frame.c
@@ -299,7 +299,7 @@ stse_ReturnCode_t stse_frame_receive(stse_Handler_t* pSTSE, stse_frame_t* pFrame
     while ((retry_count != 0) && (ret == STSE_PLATFORM_BUS_ACK_ERROR))
     {
 		/* - Receive frame length from target STSAFE */
-		ret = (stse_ReturnCode_t)pSTSE->io.BusRecvStart(
+		ret = pSTSE->io.BusRecvStart(
 				pSTSE->io.Busaddr,
 				pSTSE->io.Devaddr,
 				pSTSE->io.BusSpeed,

--- a/core/stse_frame.h
+++ b/core/stse_frame.h
@@ -77,7 +77,7 @@ typedef enum {
  * \brief 			Attach a strap element that reroute a frame element (Element1) to another (Element2)
  * \details 		This core function attach a strap element that link Element1 to Element2 until un-strap command is executed
  * \param[in] 		pStrap 			Pointer to strap element
-  * \param[in] 		pElement_1 		Pointer to frame element 1
+ * \param[in] 		pElement_1 		Pointer to frame element 1
  * \param[in] 		pElement_2 		Pointer to frame element 2
  */
 void stse_frame_insert_strap(stse_frame_element_t *pStrap, stse_frame_element_t* pElement_1,

--- a/core/stse_platform.c
+++ b/core/stse_platform.c
@@ -33,7 +33,7 @@ __WEAK stse_ReturnCode_t stse_platform_hmac_sha256_compute(PLAT_UI8 *pSalt, PLAT
 											 PLAT_UI8 *pInfo, PLAT_UI16 info_length,
 											 PLAT_UI8 *pOutput_keying_material, PLAT_UI16 output_keying_material_length)
 {
-	PLAT_UI8 retval;
+	stse_ReturnCode_t retval;
 	PLAT_UI8 pPseudorandom_key[STSAFEA_SHA_256_HASH_SIZE];
 
 

--- a/core/stse_platform.h
+++ b/core/stse_platform.h
@@ -376,60 +376,60 @@ stse_ReturnCode_t stse_platform_i2c_init (PLAT_UI8 busID);
 
 stse_ReturnCode_t stse_platform_i2c_send (PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI8* pFrame,
 		PLAT_UI16 FrameLength);
 
 stse_ReturnCode_t stse_platform_i2c_receive (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI8* pFrame_header,
 		PLAT_UI8* pFrame_payload,
 		PLAT_UI16* pFrame_payload_Length);
 
 stse_ReturnCode_t stse_platform_i2c_wake (PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed);
+		PLAT_UI16 speed);
 
 
 stse_ReturnCode_t stse_platform_i2c_send_start (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI16 FrameLength);
 
 stse_ReturnCode_t stse_platform_i2c_send_continue (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI8* pElement,
 		PLAT_UI16 element_size);
 
 stse_ReturnCode_t stse_platform_i2c_send_stop (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI8* pElement,
 		PLAT_UI16 element_size);
 
 stse_ReturnCode_t stse_platform_i2c_receive_start (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI16 *pFrame_Length);
 
 stse_ReturnCode_t stse_platform_i2c_receive_continue (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI8* pElement,
 		PLAT_UI16 element_size);
 
 stse_ReturnCode_t stse_platform_i2c_receive_stop (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
-		PLAT_UI8 speed,
+		PLAT_UI16 speed,
 		PLAT_UI8* pElement,
 		PLAT_UI16 element_size);
 

--- a/core/stse_platform.h
+++ b/core/stse_platform.h
@@ -413,7 +413,7 @@ stse_ReturnCode_t stse_platform_i2c_send_stop (
 		PLAT_UI8* pElement,
 		PLAT_UI16 element_size);
 
-PLAT_UI16 stse_platform_i2c_receive_start (
+stse_ReturnCode_t stse_platform_i2c_receive_start (
 		PLAT_UI8 busID,
 		PLAT_UI8 devAddr,
 		PLAT_UI8 speed,

--- a/services/stsafea/stsafea_asymmetric_key_slots.c
+++ b/services/stsafea/stsafea_asymmetric_key_slots.c
@@ -233,7 +233,7 @@ stse_ReturnCode_t stsafea_query_generic_public_key_slot_info(
 		stse_ecc_key_type_t curve_id_index;
 		*pKey_type = STSE_ECC_KT_INVALID;
 		/* Compare slot curve ID against each known curve ID to set the key type */
-		for(curve_id_index=(stse_ecc_key_type_t)0; curve_id_index<STSAFEA_ECC_NUMBER_OF_CURVES; curve_id_index++)
+		for(curve_id_index=STSE_ECC_KT_NIST_P_256; curve_id_index<STSAFEA_ECC_NUMBER_OF_CURVES; curve_id_index++)
 		{
 			/* First check of the ID length to speed-up the loop */
 			if(stsafea_ecc_info_table[curve_id_index].curve_id_total_length == eCurve_id.length)

--- a/services/stsafea/stsafea_asymmetric_key_slots.c
+++ b/services/stsafea/stsafea_asymmetric_key_slots.c
@@ -231,9 +231,9 @@ stse_ReturnCode_t stsafea_query_generic_public_key_slot_info(
 	if(*pPresence_flag == 1)
 	{
 		stse_ecc_key_type_t curve_id_index;
-		*pKey_type = 0;
+		*pKey_type = (stse_ecc_key_type_t)0;
 		/* Compare slot curve ID against each known curve ID to set the key type */
-		for(curve_id_index=0; curve_id_index<STSAFEA_ECC_NUMBER_OF_CURVES; curve_id_index++)
+		for(curve_id_index=(stse_ecc_key_type_t)0; curve_id_index<STSAFEA_ECC_NUMBER_OF_CURVES; curve_id_index++)
 		{
 			/* First check of the ID length to speed-up the loop */
 			if(stsafea_ecc_info_table[curve_id_index].curve_id_total_length == eCurve_id.length)

--- a/services/stsafea/stsafea_asymmetric_key_slots.c
+++ b/services/stsafea/stsafea_asymmetric_key_slots.c
@@ -231,7 +231,7 @@ stse_ReturnCode_t stsafea_query_generic_public_key_slot_info(
 	if(*pPresence_flag == 1)
 	{
 		stse_ecc_key_type_t curve_id_index;
-		*pKey_type = (stse_ecc_key_type_t)0;
+		*pKey_type = STSE_ECC_KT_INVALID;
 		/* Compare slot curve ID against each known curve ID to set the key type */
 		for(curve_id_index=(stse_ecc_key_type_t)0; curve_id_index<STSAFEA_ECC_NUMBER_OF_CURVES; curve_id_index++)
 		{
@@ -251,7 +251,7 @@ stse_ReturnCode_t stsafea_query_generic_public_key_slot_info(
 		}
 		/* If the comparison loop reach the end and pKey_type is always as initialized return error */
 		if((curve_id_index+1) == STSAFEA_ECC_NUMBER_OF_CURVES
-		&& *pKey_type==0)
+		&& *pKey_type==STSE_ECC_KT_INVALID)
 		{
 			return STSE_UNEXPECTED_ERROR;
 		}

--- a/services/stsafea/stsafea_commands.c
+++ b/services/stsafea/stsafea_commands.c
@@ -107,7 +107,7 @@ stse_ReturnCode_t stsafea_get_command_AC_table(stse_Handler_t *pSTSE,
 		} else {
 			pRecord_table[record_index].extended_header = 0;
 		}
-		pRecord_table[record_index].command_AC 			  = raw_data[record_array_pos++];
+		pRecord_table[record_index].command_AC 			  = (stse_cmd_access_conditions_t)raw_data[record_array_pos++];
 		pRecord_table[record_index].host_encryption_flags.cmd = (raw_data[record_array_pos] & 0x02) >> 1;
 		pRecord_table[record_index].host_encryption_flags.rsp = (raw_data[record_array_pos++] & 0x01);
 	}
@@ -187,12 +187,12 @@ stse_ReturnCode_t stsafea_perso_info_update (stse_Handler_t *pSTSE)
 
 void stsafea_perso_info_get_cmd_AC (stse_perso_info_t* pPerso , PLAT_UI8 command_code , stse_cmd_access_conditions_t *pProtection)
 {
-	*pProtection = ((pPerso->cmd_AC_status >> (command_code + command_code)) & 0x03);
+	*pProtection = (stse_cmd_access_conditions_t)((pPerso->cmd_AC_status >> (command_code + command_code)) & 0x03);
 }
 
 void stsafea_perso_info_get_ext_cmd_AC (stse_perso_info_t* pPerso , PLAT_UI8 command_code , stse_cmd_access_conditions_t *pProtection)
 {
-	*pProtection = ((pPerso->ext_cmd_AC_status >> (command_code + command_code)) & 0x03);
+	*pProtection = (stse_cmd_access_conditions_t)((pPerso->ext_cmd_AC_status >> (command_code + command_code)) & 0x03);
 }
 
 void stsafea_perso_info_get_cmd_encrypt_flag (stse_perso_info_t* pPerso,PLAT_UI8 command_code, PLAT_UI8 *pEnc_flag)

--- a/services/stsafea/stsafea_data_partition.c
+++ b/services/stsafea/stsafea_data_partition.c
@@ -102,10 +102,10 @@ stse_ReturnCode_t stsafea_get_data_partitions_configuration( stse_Handler_t* pST
 		{
 			pRecord_table->index = raw_data[i++];
 			pRecord_table->zone_type = raw_data[i++];
-			pRecord_table->read_ac_cr = STSAFEA_ZIR_AC_READ_CR_GET(raw_data[i]);
-			pRecord_table->read_ac = STSAFEA_ZIR_AC_READ_GET(raw_data[i]);
-			pRecord_table->update_ac_cr = STSAFEA_ZIR_AC_UPDATE_CR_GET(raw_data[i]);
-			pRecord_table->update_ac = STSAFEA_ZIR_AC_UPDATE_GET(raw_data[i++]);
+			pRecord_table->read_ac_cr = (stsafea_ac_change_right_t)STSAFEA_ZIR_AC_READ_CR_GET(raw_data[i]);
+			pRecord_table->read_ac = (stsafea_ac_t)STSAFEA_ZIR_AC_READ_GET(raw_data[i]);
+			pRecord_table->update_ac_cr = (stsafea_ac_change_right_t)STSAFEA_ZIR_AC_UPDATE_CR_GET(raw_data[i]);
+			pRecord_table->update_ac = (stsafea_ac_t)STSAFEA_ZIR_AC_UPDATE_GET(raw_data[i++]);
 			pRecord_table->data_segment_length = UI16_B1_SET(raw_data[i++]);
 			pRecord_table->data_segment_length += UI16_B0_SET(raw_data[i++]);
 			if(pRecord_table->zone_type == 1)

--- a/services/stsafea/stsafea_host_key_slot.c
+++ b/services/stsafea/stsafea_host_key_slot.c
@@ -231,7 +231,7 @@ stse_ReturnCode_t stsafea_host_key_provisioning (
 		return( STSE_SERVICE_INVALID_PARAMETER );
 	}
 
-	PLAT_UI8 host_keys_length = key_type == STSAFEA_AES_128_HOST_KEY ? STSAFEA_HOST_AES_128_KEYS_SIZE : STSAFEA_HOST_AES_256_KEYS_SIZE;
+	PLAT_UI8 host_keys_length = (key_type == STSAFEA_AES_128_HOST_KEY ? STSAFEA_HOST_AES_128_KEYS_SIZE : STSAFEA_HOST_AES_256_KEYS_SIZE);
 
 	PLAT_UI8 cmd_header = STSAFEA_EXTENDED_COMMAND_PREFIX;
 	PLAT_UI8 ext_cmd_header = STSAFEA_EXTENDED_CMD_WRITE_HOST_KEY_V2_PLAINTEXT;
@@ -242,7 +242,7 @@ stse_ReturnCode_t stsafea_host_key_provisioning (
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header,STSAFEA_HEADER_SIZE,&cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,eExt_cmd_header,STSAFEA_HEADER_SIZE,&ext_cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,ePadding,3,pPadding);
-	stse_frame_element_allocate_push(&CmdFrame,eKey_type,1,&key_type);
+	stse_frame_element_allocate_push(&CmdFrame,eKey_type,1,(PLAT_UI8*)&key_type);
 	stse_frame_element_allocate_push(&CmdFrame,eHost_keys,host_keys_length,(PLAT_UI8*)host_keys);
 
 	stse_frame_allocate(RspFrame);

--- a/services/stsafea/stsafea_put_query.c
+++ b/services/stsafea/stsafea_put_query.c
@@ -36,7 +36,7 @@ stse_ReturnCode_t stsafea_put_life_cyle_state(
 	stse_frame_allocate(CmdFrame);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header,1,&cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,eTag,1,&tag);
-	stse_frame_element_allocate_push(&CmdFrame,eLifeCycleState,1,&life_cycle_state);
+	stse_frame_element_allocate_push(&CmdFrame,eLifeCycleState,1,(PLAT_UI8*)&life_cycle_state);
 
 	/*- Create Rsp frame and populate elements*/
 	stse_frame_allocate(RspFrame);
@@ -73,7 +73,7 @@ stse_ReturnCode_t stsafea_query_life_cycle_state(
 	/*- Create Rsp frame and populate elements*/
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,1,&rsp_header);
-	stse_frame_element_allocate_push(&RspFrame,eLife_cycle_state,1,pLife_cycle_state);
+	stse_frame_element_allocate_push(&RspFrame,eLife_cycle_state,1,(PLAT_UI8*)pLife_cycle_state);
 
 	/*- Perform Transfer*/
 	ret = stse_frame_transfer(pSTSAFE,

--- a/services/stsafea/stsafea_sessions.c
+++ b/services/stsafea/stsafea_sessions.c
@@ -74,10 +74,10 @@ stse_ReturnCode_t stsafea_open_host_session( stse_Handler_t *pSTSE, stse_session
 
 void stsafea_close_host_session(stse_session_t *pSession)
 {
-	stsafea_session_erase_context(pSession);
+	stsafea_session_clear_context(pSession);
 }
 
-void stsafea_session_erase_context(stse_session_t *pSession)
+void stsafea_session_clear_context(stse_session_t *pSession)
 {
 	/* - Check stsafe handler initialization */
 	if (pSession==NULL)

--- a/services/stsafea/stsafea_sessions.c
+++ b/services/stsafea/stsafea_sessions.c
@@ -44,7 +44,7 @@ stse_ReturnCode_t stsafea_open_host_session( stse_Handler_t *pSTSE, stse_session
 		{
 			return STSE_SERVICE_SESSION_ERROR;
 		}
-		pSession->context.host.key_type = host_key_slot.key_type;
+		pSession->context.host.key_type = (stse_aes_key_type_t)host_key_slot.key_type;
 		pSession->context.host.MAC_counter = ARRAY_4B_SWAP_TO_UI32(host_key_slot.cmac_sequence_counter);
 	} else {
 		stsafea_host_key_slot_t host_key_slot;

--- a/services/stsafea/stsafea_sessions.h
+++ b/services/stsafea/stsafea_sessions.h
@@ -25,7 +25,7 @@
 #include "core/stse_platform.h"
 #include "core/stse_generic_typedef.h"
 
-#define stsafea_session_handler_allocate(session) stse_session_t session = {0}
+#define stsafea_session_handler_allocate(session) stse_session_t session
 
 /*!
  * \brief 		This Core function Create a session context and associate it to STSAFE handler
@@ -54,7 +54,7 @@ void stsafea_close_host_session(stse_session_t *pSession);
  * \return \ref stsafe_ReturnCode_t : STSAFE_OK on success ; error code otherwise
  * \details 	\include{doc} stsafe_erase_context.dox
  */
-void stsafea_session_erase_context (stse_session_t *pSession);
+void stsafea_session_clear_context (stse_session_t *pSession);
 
 
 stse_ReturnCode_t stsafea_session_encrypted_transfer ( stse_session_t *pSession,

--- a/services/stsafea/stsafea_symmetric_key_slots.c
+++ b/services/stsafea/stsafea_symmetric_key_slots.c
@@ -603,7 +603,7 @@ stse_ReturnCode_t stsafea_write_symmetric_key_plaintext(
 	stse_frame_allocate(CmdFrame);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header,STSAFEA_HEADER_SIZE,&cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,eExt_cmd_header,1,&ext_cmd_header);
-	stse_frame_element_allocate_push(&CmdFrame,eSymmetric_key_info,pSymmetric_key_info->info_length,&pSymmetric_key_info->lock_indicator);
+	stse_frame_element_allocate_push(&CmdFrame,eSymmetric_key_info,pSymmetric_key_info->info_length,(PLAT_UI8*)&pSymmetric_key_info->lock_indicator);
 	stse_frame_element_allocate_push(&CmdFrame,eSymmetric_key_value,key_value_length,pSymmetric_key_value);
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,STSAFEA_HEADER_SIZE,&rsp_header);


### PR DESCRIPTION
1. New STSE handler initialization
2. Cast of variables for MISRA compliancy
3. Rename stsafea_session_erase_context to stsafea_session_clear_context
4. Add clear session context after allocation