### PR TITLE
Prevent null pointer dereference in frame management and use full AES block sized arrays intermediate buffer to compute CMAC

### DIFF
--- a/core/stse_frame.c
+++ b/core/stse_frame.c
@@ -90,7 +90,7 @@ void stse_frame_unstrap(stse_frame_t* pFrame)
 		pFrame->length += pElement->length;
 		pFrame->element_count ++;
 		pFrame->last_element = pElement;
-		if((pElement->next->length == 0) && (pElement->next->pData!=NULL))
+		if((pElement->next != NULL) && (pElement->next->length == 0) && (pElement->next->pData!=NULL))
 		{
 			pElement->next = (stse_frame_element_t *)pElement->next->pData;
 		}

--- a/services/stsafea/stsafea_sessions.c
+++ b/services/stsafea/stsafea_sessions.c
@@ -44,7 +44,7 @@ stse_ReturnCode_t stsafea_open_host_session( stse_Handler_t *pSTSE, stse_session
 		{
 			return STSE_SERVICE_SESSION_ERROR;
 		}
-
+		pSession->context.host.key_type = host_key_slot.key_type;
 		pSession->context.host.MAC_counter = ARRAY_4B_SWAP_TO_UI32(host_key_slot.cmac_sequence_counter);
 	} else {
 		stsafea_host_key_slot_t host_key_slot;
@@ -59,7 +59,7 @@ stse_ReturnCode_t stsafea_open_host_session( stse_Handler_t *pSTSE, stse_session
 		{
 			return STSE_SERVICE_SESSION_ERROR;
 		}
-
+		pSession->context.host.key_type = STSE_AES_128_KT;
 		pSession->context.host.MAC_counter = ARRAY_3B_SWAP_TO_UI32(host_key_slot.cmac_sequence_counter);
 	}
 

--- a/services/stsafea/stsafea_sessions.c
+++ b/services/stsafea/stsafea_sessions.c
@@ -379,13 +379,14 @@ static stse_ReturnCode_t stsafea_session_frame_c_mac_compute( stse_session_t *pS
 	}
 
 	/*- Finish AES MAC computation */
-	ret = stse_platform_aes_cmac_compute_finish(pMAC,&mac_output_length);
+	ret = stse_platform_aes_cmac_compute_finish(aes_cmac_block,&mac_output_length);
 	if(ret != STSE_OK)
 	{
 		return ret;
 	} else if ( mac_output_length != STSAFEA_MAC_SIZE )  {
 		return STSE_CORE_SESSION_ERROR ;
 	}
+	memcpy(pMAC, aes_cmac_block, STSAFEA_MAC_SIZE);
 
 	return ret;
 }
@@ -526,7 +527,8 @@ static stse_ReturnCode_t stsafea_session_frame_r_mac_verify( stse_session_t *pSe
 			}
 		}
 
-		ret = stse_platform_aes_cmac_verify_finish(pMAC);
+		memcpy(aes_cmac_block, pMAC, STSAFEA_MAC_SIZE);
+		ret = stse_platform_aes_cmac_verify_finish(aes_cmac_block);
 
 	}
 	return ret;


### PR DESCRIPTION
Various fixes :
* Prevent dereferencing null pointer when reaching end of linked list of elements in frame management.
* Use full 16 bytes (AES block size) temporary buffer to compute CMAC, then truncate to STSAFEA MAC size.
* Add missing initialization of key_type for host session, depending on STSAFEA type and result of query.