### PR TITLE
[services/stsafea] support_request #1282885 : STSAFE-A120 Encryption error 0x0201 when frame is near to 256 bytes

### DIFF
--- a/services/stsafea/stsafea_sessions.c
+++ b/services/stsafea/stsafea_sessions.c
@@ -544,8 +544,8 @@ stse_ReturnCode_t stsafea_session_encrypted_transfer ( stse_session_t *pSession,
 )
 {
 	stse_ReturnCode_t ret;
-	PLAT_UI8 encrypted_cmd_payload_size = 0;
-	PLAT_UI8 encrypted_rsp_payload_size = 0;
+	PLAT_UI16 encrypted_cmd_payload_size = 0;
+	PLAT_UI16 encrypted_rsp_payload_size = 0;
 	PLAT_UI8 padding = 0;
 
 	if(cmd_encryption_flag == 1)


### PR DESCRIPTION
**Issue reported by Benjamin BARATTE**
Test done with envelop size of 240 bytes, the stsafea_wrap_payload exit with error code 0x0201

The issue is related to the code in stsafea_session_encrypted_transfer()

PLAT_UI8 encrypted_cmd_payload_size = 0;
PLAT_UI8 encrypted_rsp_payload_size = 0;

This is working fine as long as the rounded frame is less than 256 bytes, otherwise the encrypted_cmd_payload_size wrapped around and an error is return.

these variables shall be PLAT_UI16