### PR TITLE
Rename data storage's api to reflect zone's type (data_zone or counter_zone)

### DIFF
--- a/api/stse_data_storage.c
+++ b/api/stse_data_storage.c
@@ -122,7 +122,7 @@ stse_ReturnCode_t stse_data_storage_update_data_zone(
 	stsafea_update_option_t options;
 
 	options.atomicity = atomicity;
-	options.change_ac_indicator = AC_MOD_CHANGE;
+	options.change_ac_indicator = STSAFEA_AC_CHANGE;
 	options.filler = 0;
 	options.new_update_ac = STSAFEA_AC_ALWAYS;
 	options.new_update_ac_change_right = STSAFE_ACCR_DISABLED;
@@ -160,7 +160,7 @@ stse_ReturnCode_t stse_data_storage_decrement_counter_zone(
 ){
 	stsafea_decrement_option_t options;
 
-	options.change_ac_indicator = AC_MOD_CHANGE;
+	options.change_ac_indicator = STSAFEA_AC_CHANGE;
 	options.filler = 0;
 	options.new_decrement_ac = STSAFEA_AC_ALWAYS;
 	options.new_decrement_ac_change_right = STSAFE_ACCR_DISABLED;
@@ -199,7 +199,7 @@ stse_ReturnCode_t stse_data_storage_read_counter_zone(
 	PLAT_UI16 chunck_length = 0;
 	PLAT_UI16 chunck_offset = offset;
 
-	options.change_ac_indicator = AC_MOD_CHANGE;
+	options.change_ac_indicator = STSAFEA_AC_CHANGE;
 	options.filler = 0;
 	options.new_read_ac = STSAFEA_AC_ALWAYS;
 	options.new_read_ac_change_right = STSAFE_ACCR_DISABLED;
@@ -264,7 +264,7 @@ stse_ReturnCode_t stse_data_storage_change_read_access_condition(
 
 	stsafea_read_option_t options;
 
-	options.change_ac_indicator = AC_MOD_IGNORE;
+	options.change_ac_indicator = STSAFEA_AC_IGNORE;
 	options.filler = 0;
 	options.new_read_ac = ac;
 	options.new_read_ac_change_right = ac_change_right;
@@ -299,7 +299,7 @@ stse_ReturnCode_t stse_data_storage_change_update_access_condition(stse_Handler_
 	stsafea_update_option_t options;
 
 	/*- Prepare update options */
-	options.change_ac_indicator = AC_MOD_IGNORE;
+	options.change_ac_indicator = STSAFEA_AC_IGNORE;
 	options.filler = 0;
 	options.new_update_ac = ac;
 	options.new_update_ac_change_right = ac_change_right;
@@ -332,7 +332,7 @@ stse_ReturnCode_t stse_data_storage_change_decrement_access_condition(stse_Handl
 ){
 	stsafea_decrement_option_t options;
 
-	options.change_ac_indicator = AC_MOD_IGNORE;
+	options.change_ac_indicator = STSAFEA_AC_IGNORE;
 	options.filler = 0;
 	options.new_decrement_ac = ac;
 	options.new_decrement_ac_change_right = ac_change_right;

--- a/api/stse_data_storage.c
+++ b/api/stse_data_storage.c
@@ -44,7 +44,7 @@ stse_ReturnCode_t stse_data_storage_get_partitioning_table(
 			Partitioning_table_length);
 }
 
-stse_ReturnCode_t stse_data_storage_read_zone(
+stse_ReturnCode_t stse_data_storage_read_data_zone(
 		stse_Handler_t * pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI16 offset,
@@ -108,7 +108,7 @@ stse_ReturnCode_t stse_data_storage_read_zone(
 	return(ret);
 }
 
-stse_ReturnCode_t stse_data_storage_update_zone(
+stse_ReturnCode_t stse_data_storage_update_data_zone(
 		stse_Handler_t * pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI16 offset,
@@ -148,7 +148,7 @@ stse_ReturnCode_t stse_data_storage_update_zone(
 	return(ret);
 }
 
-stse_ReturnCode_t stse_data_storage_decrement_counter(
+stse_ReturnCode_t stse_data_storage_decrement_counter_zone(
 		stse_Handler_t * pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI32 amount,
@@ -183,7 +183,7 @@ stse_ReturnCode_t stse_data_storage_decrement_counter(
 	);
 }
 
-stse_ReturnCode_t stse_data_storage_read_counter(
+stse_ReturnCode_t stse_data_storage_read_counter_zone(
 		stse_Handler_t * pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI16 offset,

--- a/api/stse_data_storage.h
+++ b/api/stse_data_storage.h
@@ -77,7 +77,7 @@ stse_ReturnCode_t stse_data_storage_get_partitioning_table(
  * \note 		- If command response protection is required an active session between Host/Companion and STSAFE must be open
  * \details 	\include{doc} stse_data_storage_read_zone.dox
  */
-stse_ReturnCode_t stse_data_storage_read_zone(
+stse_ReturnCode_t stse_data_storage_read_data_zone(
 		stse_Handler_t *pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI16 offset,
@@ -101,7 +101,7 @@ stse_ReturnCode_t stse_data_storage_read_zone(
  * \note 		- If command response protection is required an active session between Host/Companion and STSAFE must be open
  * \details 	\include{doc} stse_data_storage_update_zone.dox
  */
-stse_ReturnCode_t stse_data_storage_update_zone(
+stse_ReturnCode_t stse_data_storage_update_data_zone(
 		stse_Handler_t *pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI16 offset,
@@ -126,7 +126,7 @@ stse_ReturnCode_t stse_data_storage_update_zone(
  * \note 		- If command response protection is required an active session between Host/Companion and STSAFE must be open
  * \details 	\include{doc} stse_data_storage_decrement_counter.dox
  */
-stse_ReturnCode_t stse_data_storage_decrement_counter(
+stse_ReturnCode_t stse_data_storage_decrement_counter_zone(
 		stse_Handler_t *pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI32 amount,
@@ -152,7 +152,7 @@ stse_ReturnCode_t stse_data_storage_decrement_counter(
  * \note 		- If command response protection is required an active session between Host/Companion and STSAFE must be open
  * \details 	\include{doc} stse_data_storage_read_counter.dox
  */
-stse_ReturnCode_t stse_data_storage_read_counter(
+stse_ReturnCode_t stse_data_storage_read_counter_zone(
 		stse_Handler_t *pSTSE,
 		PLAT_UI32 zone,
 		PLAT_UI16 offset,

--- a/api/stse_device_authentication.c
+++ b/api/stse_device_authentication.c
@@ -45,7 +45,7 @@ stse_ReturnCode_t stse_get_device_id(stse_Handler_t * pSTSE, PLAT_UI8* device_id
 		return( STSE_API_HANDLER_NOT_INITIALISED );
 	}
 
-	ret = stse_data_storage_read_zone(
+	ret = stse_data_storage_read_data_zone(
 			pSTSE,							/* STSAFE handler */
 			STSAFE_CERTIFICATE_ZONE_0,		/* Zone = 0 */
 			CERTIFICATE_DEVICE_ID_OFFSET,	/* X bytes offset */
@@ -69,7 +69,7 @@ stse_ReturnCode_t stse_get_device_certificate_size(stse_Handler_t * pSTSE, PLAT_
 	}
 
 
-	ret = stse_data_storage_read_zone(
+	ret = stse_data_storage_read_data_zone(
 			pSTSE,							/* STSAFE handler */
 			STSAFE_CERTIFICATE_ZONE_0,		/* Zone = 0 */
 			CERTIFICATE_SIZE_OFFSET_BYTES,	/* 2 bytes offset */
@@ -99,7 +99,7 @@ stse_ReturnCode_t stse_get_device_certificate(stse_Handler_t * pSTSE, PLAT_UI16 
 		return( STSE_API_HANDLER_NOT_INITIALISED );
 	}
 
-	ret = stse_data_storage_read_zone(
+	ret = stse_data_storage_read_data_zone(
 			pSTSE,							/* STSAFE handler */
 			STSAFE_CERTIFICATE_ZONE_0,		/* Zone = 0 */
 			CERTIFICATE_OFFSET_BYTES,		/* 0 bytes offset */

--- a/api/stse_symmetric_keys_management.c
+++ b/api/stse_symmetric_keys_management.c
@@ -551,7 +551,7 @@ stse_ReturnCode_t stse_host_key_provisioning_wrapped (
 	PLAT_UI8 host_key_envelope[host_keys_envelope_length];
 
 
-	stsafea_session_handler_allocate(volatile_KEK_session);
+	stse_session_t volatile_KEK_session;
 	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start volatile KEK  */
@@ -645,7 +645,7 @@ stse_ReturnCode_t stse_host_key_provisioning_wrapped_authenticated (
 
 	PLAT_UI8 host_key_envelope[host_keys_envelope_length];
 
-	stsafea_session_handler_allocate(volatile_KEK_session);
+	stse_session_t volatile_KEK_session;
 	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start volatile KEK Authenticated */
@@ -823,7 +823,7 @@ stse_ReturnCode_t stse_write_symmetric_key_wrapped(
 		return( STSE_API_HANDLER_NOT_INITIALISED );
 	}
 
-	stsafea_session_handler_allocate(volatile_KEK_session);
+	stse_session_t volatile_KEK_session;
 	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start Volatile KEK session */
@@ -905,7 +905,7 @@ stse_ReturnCode_t stse_write_symmetric_key_wrapped_authenticated (
 		return( STSE_COMMAND_CODE_NOT_SUPPORTED );
 	}
 
-	stsafea_session_handler_allocate(volatile_KEK_session);
+	stse_session_t volatile_KEK_session;
 	stsafea_session_clear_context(&volatile_KEK_session);
 
 	/* - Start volatile KEK Authenticated */

--- a/core/stse_session.h
+++ b/core/stse_session.h
@@ -24,9 +24,6 @@
 #include "core/stse_frame.h"
 #include "core/stse_generic_typedef.h"
 
-
-#define stse_session_allocate(session) stse_session_t session = {0}
-
 /*!
  * \brief 		This Core function Erase the session context from STSAFE handler
  * \param[in] 	*pSTSE 	Pointer to target STSAFE handler

--- a/services/stsafea/stsafea_data_partition.h
+++ b/services/stsafea/stsafea_data_partition.h
@@ -34,18 +34,18 @@
  */
 
 /* Zone Info Record (ZIR) bitfields definition  */
-#define STSAFEA_ZIR_AC_READ_CR_Pos  			7
+#define STSAFEA_ZIR_AC_READ_CR_Pos  		7
 #define STSAFEA_ZIR_AC_READ_Pos  	 		4
-#define STSAFEA_ZIR_AC_UPDATE_CR_Pos  		        3
+#define STSAFEA_ZIR_AC_UPDATE_CR_Pos  		3
 #define STSAFEA_ZIR_AC_UPDATE_Pos	  		0
 #define STSAFEA_ZIR_AC_READ_CR_Msk 			128 /*0b10000000*/
 #define STSAFEA_ZIR_AC_READ_Msk 			112 /*0b01110000*/
-#define STSAFEA_ZIR_AC_UPDATE_CR_Msk 		        8   /*0b00001000*/
+#define STSAFEA_ZIR_AC_UPDATE_CR_Msk 		8   /*0b00001000*/
 #define STSAFEA_ZIR_AC_UPDATE_Msk 			7   /*0b00000111*/
 #define STSAFEA_ZIR_AC_READ_CR_GET(x)		( ( (x) & STSAFEA_ZIR_AC_READ_CR_Msk) >> STSAFEA_ZIR_AC_READ_CR_Pos )
 #define STSAFEA_ZIR_AC_READ_GET(x)			( ( (x) & STSAFEA_ZIR_AC_READ_Msk) >> STSAFEA_ZIR_AC_READ_Pos )
 #define STSAFEA_ZIR_AC_UPDATE_CR_GET(x)		( ( (x) & STSAFEA_ZIR_AC_UPDATE_CR_Msk) >> STSAFEA_ZIR_AC_UPDATE_CR_Pos )
-#define STSAFEA_ZIR_AC_UPDATE_GET(x)			( ( (x) & STSAFEA_ZIR_AC_UPDATE_Msk) >> STSAFEA_ZIR_AC_UPDATE_Pos )
+#define STSAFEA_ZIR_AC_UPDATE_GET(x)		( ( (x) & STSAFEA_ZIR_AC_UPDATE_Msk) >> STSAFEA_ZIR_AC_UPDATE_Pos )
 
 
 /**
@@ -73,8 +73,8 @@ typedef enum stsafea_ac_t{
  * \brief STSAFE data storage access condition change indicator
  */
 typedef enum stsafea_zone_ac_change_indicator_t {
-	AC_MOD_CHANGE = 0,		/*!< request access condition change */
-	AC_MOD_IGNORE			/*!< ignore access condition change */
+	STSAFEA_AC_CHANGE = 0,		/*!< request access condition change */
+	STSAFEA_AC_IGNORE			/*!< ignore access condition change */
 }stsafea_zone_ac_change_indicator_t;
 
 /**

--- a/services/stsafea/stsafea_sessions.h
+++ b/services/stsafea/stsafea_sessions.h
@@ -25,8 +25,6 @@
 #include "core/stse_platform.h"
 #include "core/stse_generic_typedef.h"
 
-#define stsafea_session_handler_allocate(session) stse_session_t session
-
 /*!
  * \brief 		This Core function Create a session context and associate it to STSAFE handler
  * \param[in] 	*pSession 			\ref stse_session_t Pointer to session


### PR DESCRIPTION
1. Rename data storage's api to reflect zone's type (data_zone or counter_zone)
2. Rename value of enum stsafea_zone_ac_change_indicator_t
3. Remove macro stsafea_session_handler_allocate & stse_session_allocate
