### PR TITLE
AES GCM by chunk

### DIFF
--- a/api/stse_symmetric_keys_management.c
+++ b/api/stse_symmetric_keys_management.c
@@ -794,6 +794,19 @@ stse_ReturnCode_t stse_get_symmetric_key_slot_provisioning_ctrl_fields(
 	return stsafea_query_symmetric_key_slot_provisioning_ctrl_fields(pSTSE, slot_number, pCtrl_fields);
 }
 
+stse_ReturnCode_t stse_set_symmetric_key_slot_provisioning_ctrl_fields(
+		stse_Handler_t * pSTSE,
+		PLAT_UI8 slot_number,
+		stsafea_symmetric_key_slot_provisioning_ctrl_fields_t * pCtrl_fields)
+{
+	if (pSTSE == NULL)
+	{
+		return( STSE_API_HANDLER_NOT_INITIALISED );
+	}
+
+	return stsafea_put_symmetric_key_slot_provisioning_ctrl_fields(pSTSE, slot_number, pCtrl_fields);
+}
+
 stse_ReturnCode_t stse_write_symmetric_key_plaintext(
 		stse_Handler_t * pSTSE,
 		PLAT_UI8 * pKey,

--- a/api/stse_symmetric_keys_management.h
+++ b/api/stse_symmetric_keys_management.h
@@ -142,6 +142,19 @@ stse_ReturnCode_t stse_get_symmetric_key_slot_provisioning_ctrl_fields(
 		stsafea_symmetric_key_slot_provisioning_ctrl_fields_t * pCtrl_fields);
 
 /**
+ * \brief 		Set symmetric key slot provisioning control fields
+ * \details 	Set symmetric key slot provisioning control fields
+ * \param[in] 	pSTSE 				Pointer to STSAFE Handler
+ * \param[in] 	slot_number			Slot number of the slot to query
+ * \param[in] 	pCtrl_fields		Input structure for the provisioning control fields of the target slot
+ * \return \ref stse_ReturnCode_t : STSE_OK on success ; error code otherwise
+ */
+stse_ReturnCode_t stse_set_symmetric_key_slot_provisioning_ctrl_fields(
+		stse_Handler_t * pSTSE,
+		PLAT_UI8 slot_number,
+		stsafea_symmetric_key_slot_provisioning_ctrl_fields_t * pCtrl_fields);
+
+/**
  * \brief 		Write symmetric key plaintext in stsafe symmetric key table
  * \details 	This API Write a symmetric key in stsafe symmetric key table
  * \param[in] 	pSTSE 			 	 Pointer to STSAFE Handler

--- a/core/stse_frame.c
+++ b/core/stse_frame.c
@@ -311,8 +311,12 @@ stse_ReturnCode_t stse_frame_receive(stse_Handler_t* pSTSE, stse_frame_t* pFrame
     }
 
     /* - Verify correct reception*/
-    if((ret & 0x3F)!= STSE_OK)
+    if((ret & 0x1F)!= STSE_OK)
     {
+#ifdef STSAFE_FRAME_DEBUG_LOG
+		printf("\n\r STSAFE Frame <  (1-byte) : { 0x%02X }\n\r", ret);
+		printf("\n\r");
+#endif
     	return( ret );
     }
 

--- a/services/stsafea/stsafea_aes.c
+++ b/services/stsafea/stsafea_aes.c
@@ -239,9 +239,9 @@ stse_ReturnCode_t stsafea_aes_ccm_encrypt(
 	stse_frame_element_allocate_push(&CmdFrame,eSub_command_distinguisher,1,&sub_command_distinguisher);
 	stse_frame_element_allocate_push(&CmdFrame,eSlot_number,1,&slot_number);
 	stse_frame_element_allocate_push(&CmdFrame,eNonce,STSAFEA_NONCE_SIZE,pNonce);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_length);
 	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_length);
 	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_length,pPlaintext_message);
 
 	/* - Prepare RSP Frame : [HEADER] [ENCRYPTED MESSAGE] [TAG LENGTH] [COUNTER PRES.] [COUNTER VAL] */
@@ -354,9 +354,9 @@ stse_ReturnCode_t stsafea_aes_ccm_decrypt(
 	stse_frame_element_allocate_push(&CmdFrame,eSub_command_distinguisher,1,&sub_command_distinguisher);
 	stse_frame_element_allocate_push(&CmdFrame,eSlot_number,1,&slot_number);
 	stse_frame_element_allocate_push(&CmdFrame,eNonce,STSAFEA_NONCE_SIZE,pNonce);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_length);
 	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&encrypted_message_length);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&encrypted_message_length);
 	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_length,pEncrypted_message);
 	stse_frame_element_allocate_push(&CmdFrame,eAuthentication_tag,authentication_tag_length,pAuthentication_tag);
 
@@ -453,9 +453,9 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt(
 	stse_frame_element_allocate_push(&CmdFrame,eSlot_number,1,&slot_number);
 	stse_frame_element_allocate_push(&CmdFrame,eIV_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&IV_length);
 	stse_frame_element_allocate_push(&CmdFrame,eIV,IV_length,pIV);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_length);
 	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_length);
 	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_length,pPlaintext_message);
 
 	/* - Prepare RSP Frame : [HEADER] [ENCRYPTED MESSAGE] [TAG LENGTH] */
@@ -499,9 +499,6 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt(
 
 	}
 
-	stse_frame_element_swap_byte_order(&eAssociated_data_length);
-	stse_frame_element_swap_byte_order(&eMessage_length);
-
 	return ret;
 }
 
@@ -510,11 +507,11 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_start(
 		PLAT_UI8 slot_number,
 		PLAT_UI16 IV_length,
 		PLAT_UI8* pIV,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pPlaintext_message,
-		PLAT_UI8 * pEncrypted_message)
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pPlaintext_message_chunk,
+		PLAT_UI8 * pEncrypted_message_chunk)
 {
 	stse_ReturnCode_t ret;
 	PLAT_UI8 cmd_header = STSAFEA_EXTENDED_COMMAND_PREFIX;
@@ -531,11 +528,11 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_start(
 	}
 
 	if((pIV == NULL || IV_length == 0)
-	|| (pAssociated_data 	== NULL && associated_data_length != 0)
-	|| (pAssociated_data 	!= NULL && associated_data_length == 0)
-	|| (pPlaintext_message 	== NULL && message_length != 0)
-	|| (pPlaintext_message 	!= NULL && message_length == 0)
-	|| (pEncrypted_message  == NULL && pPlaintext_message != NULL))
+	|| (pAssociated_data_chunk		== NULL && associated_data_chunk_length != 0)
+	|| (pAssociated_data_chunk 		!= NULL && associated_data_chunk_length == 0)
+	|| (pPlaintext_message_chunk	== NULL && message_chunk_length != 0)
+	|| (pPlaintext_message_chunk	!= NULL && message_chunk_length == 0)
+	|| (pPlaintext_message_chunk	== NULL && pPlaintext_message_chunk != NULL))
 	{
 		return( STSE_SERVICE_INVALID_PARAMETER );
 	}
@@ -551,15 +548,16 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_start(
 	stse_frame_element_allocate_push(&CmdFrame,eSlot_number,1,&slot_number);
 	stse_frame_element_allocate_push(&CmdFrame,eIV_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&IV_length);
 	stse_frame_element_allocate_push(&CmdFrame,eIV,IV_length,pIV);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
-	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_length,pPlaintext_message);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_chunk_length,pAssociated_data_chunk);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_chunk_length,pPlaintext_message_chunk);
 
 	/* - Prepare RSP Frame */
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,STSAFEA_HEADER_SIZE,&rsp_header);
-	stse_frame_element_allocate_push(&RspFrame,eEncrypted_message,message_length,pEncrypted_message);
+	stse_frame_element_allocate_push(&RspFrame,eEncrypted_message,message_chunk_length,pEncrypted_message_chunk);
+
 	stse_frame_element_swap_byte_order(&eIV_length);
 	stse_frame_element_swap_byte_order(&eAssociated_data_length);
 	stse_frame_element_swap_byte_order(&eMessage_length);
@@ -587,19 +585,16 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_start(
 				stsafea_extended_cmd_timings[pSTSE->device_type][cmd_header_ext]);
 	}
 
-	stse_frame_element_swap_byte_order(&eAssociated_data_length);
-	stse_frame_element_swap_byte_order(&eMessage_length);
-
 	return ret;
 }
 
 stse_ReturnCode_t stsafea_aes_gcm_encrypt_process(
 		stse_Handler_t * pSTSE,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pPlaintext_message,
-		PLAT_UI8 * pEncrypted_message)
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pPlaintext_message_chunk,
+		PLAT_UI8 * pEncrypted_message_chunk)
 {
 	stse_ReturnCode_t ret;
 	PLAT_UI8 cmd_header = STSAFEA_EXTENDED_COMMAND_PREFIX;
@@ -615,11 +610,11 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_process(
 		return( STSE_SERVICE_HANDLER_NOT_INITIALISED );
 	}
 
-	if((pAssociated_data 	== NULL && associated_data_length != 0)
-	|| (pAssociated_data 	!= NULL && associated_data_length == 0)
-	|| (pPlaintext_message 	== NULL && message_length != 0)
-	|| (pPlaintext_message 	!= NULL && message_length == 0)
-	|| (pEncrypted_message  == NULL && pPlaintext_message != NULL))
+	if((pAssociated_data_chunk		== NULL && associated_data_chunk_length != 0)
+	|| (pAssociated_data_chunk		!= NULL && associated_data_chunk_length == 0)
+	|| (pPlaintext_message_chunk	== NULL && message_chunk_length != 0)
+	|| (pPlaintext_message_chunk	!= NULL && message_chunk_length == 0)
+	|| (pEncrypted_message_chunk	== NULL && pPlaintext_message_chunk != NULL))
 	{
 		return( STSE_SERVICE_INVALID_PARAMETER );
 	}
@@ -632,15 +627,15 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_process(
 	stse_frame_allocate(CmdFrame);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header,STSAFEA_HEADER_SIZE,&cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header_ext,STSAFEA_HEADER_SIZE,&cmd_header_ext);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
-	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_length,pPlaintext_message);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_chunk_length,pAssociated_data_chunk);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_chunk_length,pPlaintext_message_chunk);
 
 	/* - Prepare RSP Frame */
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,STSAFEA_HEADER_SIZE,&rsp_header);
-	stse_frame_element_allocate_push(&RspFrame,eEncrypted_message,message_length,pEncrypted_message);
+	stse_frame_element_allocate_push(&RspFrame,eEncrypted_message,message_chunk_length,pEncrypted_message_chunk);
 	stse_frame_element_swap_byte_order(&eAssociated_data_length);
 	stse_frame_element_swap_byte_order(&eMessage_length);
 
@@ -667,20 +662,17 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_process(
 				stsafea_extended_cmd_timings[pSTSE->device_type][cmd_header_ext]);
 	}
 
-	stse_frame_element_swap_byte_order(&eAssociated_data_length);
-	stse_frame_element_swap_byte_order(&eMessage_length);
-
 	return ret;
 }
 
 stse_ReturnCode_t stsafea_aes_gcm_encrypt_finish(
 		stse_Handler_t * pSTSE,
 		PLAT_UI8 authentication_tag_length,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pPlaintext_message,
-		PLAT_UI8 * pEncrypted_message,
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pPlaintext_message_chunk,
+		PLAT_UI8 * pEncrypted_message_chunk,
 		PLAT_UI8 * pAuthentication_tag)
 {
 	stse_ReturnCode_t ret;
@@ -697,11 +689,11 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_finish(
 		return( STSE_SERVICE_HANDLER_NOT_INITIALISED );
 	}
 
-	if((pAssociated_data 	== NULL && associated_data_length != 0)
-	|| (pAssociated_data 	!= NULL && associated_data_length == 0)
-	|| (pPlaintext_message 	== NULL && message_length != 0)
-	|| (pPlaintext_message 	!= NULL && message_length == 0)
-	|| (pEncrypted_message  == NULL && pPlaintext_message != NULL)
+	if((pAssociated_data_chunk		== NULL && associated_data_chunk_length != 0)
+	|| (pAssociated_data_chunk		!= NULL && associated_data_chunk_length == 0)
+	|| (pPlaintext_message_chunk 	== NULL && message_chunk_length != 0)
+	|| (pPlaintext_message_chunk 	!= NULL && message_chunk_length == 0)
+	|| (pEncrypted_message_chunk	== NULL && pPlaintext_message_chunk != NULL)
 	|| (pAuthentication_tag  == NULL && authentication_tag_length == 0))
 	{
 		return( STSE_SERVICE_INVALID_PARAMETER );
@@ -715,15 +707,15 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_finish(
 	stse_frame_allocate(CmdFrame);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header,STSAFEA_HEADER_SIZE,&cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header_ext,STSAFEA_HEADER_SIZE,&cmd_header_ext);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
-	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_length,pPlaintext_message);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_chunk_length,pAssociated_data_chunk);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,ePlaintext_message,message_chunk_length,pPlaintext_message_chunk);
 
 	/* - Prepare RSP Frame */
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,STSAFEA_HEADER_SIZE,&rsp_header);
-	stse_frame_element_allocate_push(&RspFrame,eEncrypted_message,message_length,pEncrypted_message);
+	stse_frame_element_allocate_push(&RspFrame,eEncrypted_message,message_chunk_length,pEncrypted_message_chunk);
 	stse_frame_element_allocate_push(&RspFrame,eAuthentication_tag,authentication_tag_length,pAuthentication_tag);
 	stse_frame_element_swap_byte_order(&eAssociated_data_length);
 	stse_frame_element_swap_byte_order(&eMessage_length);
@@ -750,9 +742,6 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_finish(
 				&RspFrame,
 				stsafea_extended_cmd_timings[pSTSE->device_type][cmd_header_ext]);
 	}
-
-	stse_frame_element_swap_byte_order(&eAssociated_data_length);
-	stse_frame_element_swap_byte_order(&eMessage_length);
 
 	return ret;
 }
@@ -811,9 +800,9 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt(
 	stse_frame_element_allocate_push(&CmdFrame,eSlot_number,1,&slot_number);
 	stse_frame_element_allocate_push(&CmdFrame,eIV_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&IV_length);
 	stse_frame_element_allocate_push(&CmdFrame,eIV,IV_length,pIV);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_length);
 	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_length);
 	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_length,pEncrypted_message);
 	stse_frame_element_allocate_push(&CmdFrame,eAuthentication_tag,authentication_tag_length,pAuthentication_tag);
 
@@ -864,11 +853,11 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_start(
 		PLAT_UI8 slot_number,
 		PLAT_UI16 IV_length,
 		PLAT_UI8* pIV,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pEncrypted_message,
-		PLAT_UI8 * pPlaintext_message)
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pEncrypted_message_chunk,
+		PLAT_UI8 * pPlaintext_message_chunk)
 {
 	stse_ReturnCode_t ret;
 	PLAT_UI8 cmd_header = STSAFEA_EXTENDED_COMMAND_PREFIX;
@@ -885,11 +874,11 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_start(
 	}
 
 	if((pIV == NULL || IV_length == 0)
-	|| (pAssociated_data 	== NULL && associated_data_length != 0)
-	|| (pAssociated_data 	!= NULL && associated_data_length == 0)
-	|| (pPlaintext_message 	== NULL && message_length != 0)
-	|| (pPlaintext_message 	!= NULL && message_length == 0)
-	|| (pEncrypted_message  == NULL && pPlaintext_message != NULL))
+	|| (pAssociated_data_chunk		== NULL && associated_data_chunk_length != 0)
+	|| (pAssociated_data_chunk		!= NULL && associated_data_chunk_length == 0)
+	|| (pPlaintext_message_chunk 	== NULL && message_chunk_length != 0)
+	|| (pPlaintext_message_chunk 	!= NULL && message_chunk_length == 0)
+	|| (pEncrypted_message_chunk	== NULL && pPlaintext_message_chunk != NULL))
 	{
 		return( STSE_SERVICE_INVALID_PARAMETER );
 	}
@@ -905,15 +894,15 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_start(
 	stse_frame_element_allocate_push(&CmdFrame,eSlot_number,1,&slot_number);
 	stse_frame_element_allocate_push(&CmdFrame,eIV_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&IV_length);
 	stse_frame_element_allocate_push(&CmdFrame,eIV,IV_length,pIV);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
-	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_length,pEncrypted_message);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_chunk_length,pAssociated_data_chunk);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_chunk_length,pEncrypted_message_chunk);
 
 	/* - Prepare RSP Frame */
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,STSAFEA_HEADER_SIZE,&rsp_header);
-	stse_frame_element_allocate_push(&RspFrame,ePlaintext_message,message_length,pPlaintext_message);
+	stse_frame_element_allocate_push(&RspFrame,ePlaintext_message,message_chunk_length,pPlaintext_message_chunk);
 	stse_frame_element_swap_byte_order(&eIV_length);
 	stse_frame_element_swap_byte_order(&eAssociated_data_length);
 	stse_frame_element_swap_byte_order(&eMessage_length);
@@ -945,11 +934,11 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_start(
 
 stse_ReturnCode_t stsafea_aes_gcm_decrypt_process(
 		stse_Handler_t * pSTSE,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pEncrypted_message,
-		PLAT_UI8 * pPlaintext_message)
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pEncrypted_message_chunk,
+		PLAT_UI8 * pPlaintext_message_chunk)
 {
 	stse_ReturnCode_t ret;
 	PLAT_UI8 cmd_header = STSAFEA_EXTENDED_COMMAND_PREFIX;
@@ -965,11 +954,11 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_process(
 		return( STSE_SERVICE_HANDLER_NOT_INITIALISED );
 	}
 
-	if((pAssociated_data 	== NULL && associated_data_length != 0)
-	|| (pAssociated_data 	!= NULL && associated_data_length == 0)
-	|| (pPlaintext_message 	== NULL && message_length != 0)
-	|| (pPlaintext_message 	!= NULL && message_length == 0)
-	|| (pEncrypted_message  == NULL && pPlaintext_message != NULL))
+	if((pAssociated_data_chunk		== NULL && associated_data_chunk_length != 0)
+	|| (pAssociated_data_chunk		!= NULL && associated_data_chunk_length == 0)
+	|| (pPlaintext_message_chunk 	== NULL && message_chunk_length != 0)
+	|| (pPlaintext_message_chunk 	!= NULL && message_chunk_length == 0)
+	|| (pEncrypted_message_chunk	== NULL && pPlaintext_message_chunk != NULL))
 	{
 		return( STSE_SERVICE_INVALID_PARAMETER );
 	}
@@ -982,15 +971,15 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_process(
 	stse_frame_allocate(CmdFrame);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header,STSAFEA_HEADER_SIZE,&cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header_ext,STSAFEA_HEADER_SIZE,&cmd_header_ext);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
-	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_length,pEncrypted_message);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_chunk_length,pAssociated_data_chunk);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_chunk_length,pEncrypted_message_chunk);
 
 	/* - Prepare RSP Frame */
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,STSAFEA_HEADER_SIZE,&rsp_header);
-	stse_frame_element_allocate_push(&RspFrame,ePlaintext_message,message_length,pPlaintext_message);
+	stse_frame_element_allocate_push(&RspFrame,ePlaintext_message,message_chunk_length,pPlaintext_message_chunk);
 	stse_frame_element_swap_byte_order(&eAssociated_data_length);
 	stse_frame_element_swap_byte_order(&eMessage_length);
 
@@ -1022,13 +1011,13 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_process(
 stse_ReturnCode_t stsafea_aes_gcm_decrypt_finish(
 		stse_Handler_t * pSTSE,
 		PLAT_UI8 authentication_tag_length,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pEncrypted_message,
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pEncrypted_message_chunk,
 		PLAT_UI8 * pAuthentication_tag,
 		PLAT_UI8 * pVerification_result,
-		PLAT_UI8 * pPlaintext_message)
+		PLAT_UI8 * pPlaintext_message_chunk)
 {
 	stse_ReturnCode_t ret;
 	PLAT_UI8 cmd_header = STSAFEA_EXTENDED_COMMAND_PREFIX;
@@ -1044,11 +1033,11 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_finish(
 		return( STSE_SERVICE_HANDLER_NOT_INITIALISED );
 	}
 
-	if((pAssociated_data 	== NULL && associated_data_length != 0)
-	|| (pAssociated_data 	!= NULL && associated_data_length == 0)
-	|| (pPlaintext_message 	== NULL && message_length != 0)
-	|| (pPlaintext_message 	!= NULL && message_length == 0)
-	|| (pEncrypted_message  == NULL && pPlaintext_message != NULL)
+	if((pAssociated_data_chunk 	== NULL && associated_data_chunk_length != 0)
+	|| (pAssociated_data_chunk 	!= NULL && associated_data_chunk_length == 0)
+	|| (pPlaintext_message_chunk 	== NULL && message_chunk_length != 0)
+	|| (pPlaintext_message_chunk 	!= NULL && message_chunk_length == 0)
+	|| (pEncrypted_message_chunk  == NULL && pPlaintext_message_chunk != NULL)
 	|| (pAuthentication_tag  == NULL && authentication_tag_length == 0))
 	{
 		return( STSE_SERVICE_INVALID_PARAMETER );
@@ -1062,17 +1051,17 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_finish(
 	stse_frame_allocate(CmdFrame);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header,STSAFEA_HEADER_SIZE,&cmd_header);
 	stse_frame_element_allocate_push(&CmdFrame,eCmd_header_ext,STSAFEA_HEADER_SIZE,&cmd_header_ext);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,2,(PLAT_UI8*)&associated_data_length);
-	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_length,pAssociated_data);
-	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,2,(PLAT_UI8*)&message_length);
-	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_length,pEncrypted_message);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&associated_data_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eAssociated_data,associated_data_chunk_length,pAssociated_data_chunk);
+	stse_frame_element_allocate_push(&CmdFrame,eMessage_length,STSAFEA_GENERIC_LENGTH_SIZE,(PLAT_UI8*)&message_chunk_length);
+	stse_frame_element_allocate_push(&CmdFrame,eEncrypted_message,message_chunk_length,pEncrypted_message_chunk);
 	stse_frame_element_allocate_push(&CmdFrame,eAuthentication_tag,authentication_tag_length,pAuthentication_tag);
 
 	/* - Prepare RSP Frame */
 	stse_frame_allocate(RspFrame);
 	stse_frame_element_allocate_push(&RspFrame,eRsp_header,STSAFEA_HEADER_SIZE,&rsp_header);
 	stse_frame_element_allocate_push(&RspFrame,eVerification_result,1,pVerification_result);
-	stse_frame_element_allocate_push(&RspFrame,ePlaintext_message,message_length,pPlaintext_message);
+	stse_frame_element_allocate_push(&RspFrame,ePlaintext_message,message_chunk_length,pPlaintext_message_chunk);
 	stse_frame_element_swap_byte_order(&eAssociated_data_length);
 	stse_frame_element_swap_byte_order(&eMessage_length);
 

--- a/services/stsafea/stsafea_aes.h
+++ b/services/stsafea/stsafea_aes.h
@@ -164,15 +164,15 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt(
 /**
  * \brief 		Start chunk encryption in AES GCM mode
  * \details 	This service start chunk encryption in AES GCM mode using the specified key from STSAFE symmetric key table
- * \param[in] 	pSTSE 						Pointer to STSAFE Handler
- * \param[in] 	slot_number 				Key slot in symmetric key table to be used
- * \param[in]	IV_length					IV buffer length in bytes
- * \param[in]	IV							IV buffer
- * \param[in]	associated_data_length		Length of the associated data
- * \param[in]	pAssociated_data			Buffer containing associated data
- * \param[in]	message_length				Length of the message to encrypt
- * \param[in]	pPlaintext_message			Buffer containing the message to encrypt
- * \param[out]	pEncrypted_message			Buffer to store the encrypted message
+ * \param[in] 	pSTSE 							Pointer to STSAFE Handler
+ * \param[in] 	slot_number 					Key slot in symmetric key table to be used
+ * \param[in]	IV_length						IV buffer length in bytes
+ * \param[in]	IV								IV buffer
+ * \param[in]	associated_data_chunk_length	Length of the associated data chunk
+ * \param[in]	pAssociated_data_chunk			Buffer containing associated data chunk
+ * \param[in]	message_chunk_length			Length of the message chunk to encrypt
+ * \param[in]	pPlaintext_message_chunk		Buffer containing the message chunk to encrypt
+ * \param[out]	pEncrypted_message_chunk		Buffer to store the encrypted message
  * \return \ref stse_ReturnCode_t : STSAFE_OK on success ; error code otherwise
  * \details 	\include{doc} stse_aes_gcm_encrypt.dox
  */
@@ -181,54 +181,54 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_start(
 		PLAT_UI8 slot_number,
 		PLAT_UI16 IV_length,
 		PLAT_UI8* pIV,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pPlaintext_message,
-		PLAT_UI8 * pEncrypted_message);
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pPlaintext_message_chunk,
+		PLAT_UI8 * pEncrypted_message_chunk);
 
 /**
  * \brief 		Process chunk encryption in AES GCM mode
  * \details 	This service process additional chunk encryption in AES GCM mode using the key specified in start command
- * \param[in] 	pSTSE 						Pointer to STSAFE Handler
- * \param[in]	associated_data_length		Length of the associated data
- * \param[in]	pAssociated_data			Buffer containing associated data
- * \param[in]	message_length				Length of the message to encrypt
- * \param[in]	pPlaintext_message			Buffer containing the message to encrypt
- * \param[out]	pEncrypted_message			Buffer to store the encrypted message
+ * \param[in] 	pSTSE 							Pointer to STSAFE Handler
+ * \param[in]	associated_data_chunk_length	Length of the associated data chunk
+ * \param[in]	pAssociated_data_chunk			Buffer containing associated data chunk
+ * \param[in]	message_chunk_length			Length of the message chunk to encrypt
+ * \param[in]	pPlaintext_message_chunk		Buffer containing the message chunk to encrypt
+ * \param[out]	pEncrypted_message_chunk		Buffer to store the encrypted message chunk
  * \return \ref stse_ReturnCode_t : STSAFE_OK on success ; error code otherwise
  * \details 	\include{doc} stse_aes_gcm_encrypt.dox
  */
 stse_ReturnCode_t stsafea_aes_gcm_encrypt_process(
 		stse_Handler_t * pSTSE,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pPlaintext_message,
-		PLAT_UI8 * pEncrypted_message);
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pPlaintext_message_chunk,
+		PLAT_UI8 * pEncrypted_message_chunk);
 
 /**
  * \brief 		Finish chunk encryption in AES GCM mode
  * \details 	This service finish chunk encryption in AES GCM mode using the key specified in start command
- * \param[in] 	pSTSE 						Pointer to STSAFE Handler
- * \param[in] 	authentication_tag_length	Length of the output authentication tag
- * \param[in]	associated_data_length		Length of the associated data
- * \param[in]	pAssociated_data			Buffer containing associated data
- * \param[in] 	chunk_length 				Length of the chunk
- * \param[in] 	pPlaintext_chunk 			Plaintext chunk to encrypt
- * \param[out] 	pEncrypted_chunk 			Encrypted chunk
- * \param[out] 	pAuthentication_tag 		Authentication tag
+ * \param[in] 	pSTSE 							Pointer to STSAFE Handler
+ * \param[in] 	authentication_tag_length		Length of the output authentication tag
+ * \param[in]	associated_data_chunk_length	Length of the associated data chunk
+ * \param[in]	pAssociated_data_chunk			Buffer containing associated data chunk
+ * \param[in] 	message_chunk_length 			Length of the message chunk
+ * \param[in] 	pPlaintext_message_chunk		Buffer containing the message chunk to encrypt
+ * \param[out] 	pEncrypted_message_chunk		Buffer to store the encrypted message chunk
+ * \param[out] 	pAuthentication_tag 			Authentication tag
  * \return \ref stse_ReturnCode_t : STSAFE_OK on success ; error code otherwise
  * \details 	\include{doc} stse_aes_gcm_encrypt.dox
  */
 stse_ReturnCode_t stsafea_aes_gcm_encrypt_finish(
 		stse_Handler_t * pSTSE,
 		PLAT_UI8 authentication_tag_length,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pPlaintext_message,
-		PLAT_UI8 * pEncrypted_message,
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pPlaintext_message_chunk,
+		PLAT_UI8 * pEncrypted_message_chunk,
 		PLAT_UI8 * pAuthentication_tag);
 
 /**
@@ -241,7 +241,7 @@ stse_ReturnCode_t stsafea_aes_gcm_encrypt_finish(
  * \param[in]	IV							IV buffer
  * \param[in]	associated_data_length		Length of the associated data
  * \param[in]	pAssociated_data			Buffer containing associated data
- * \param[in]	message_length				Length of the message to encrypt
+ * \param[in]	message_length				Length of the message to decrypt
  * \param[in]	pEncrypted_message			Buffer containing the message to decrypt
  * \param[in]	pAuthentication_tag			Buffer containing the authentication tag
  * \param[out]	pVerification_result		Verification result flag
@@ -265,15 +265,15 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt(
 /**
  * \brief 		Start chunk decryption in AES GCM mode
  * \details 	This service start chunk decryption in AES GCM mode using the specified key from STSAFE symmetric key table
- * \param[in] 	pSTSE 						Pointer to STSAFE Handler
- * \param[in] 	slot_number 				Key slot in symmetric key table to be used
- * \param[in]	IV_length					IV buffer length in bytes
- * \param[in]	IV							IV buffer
- * \param[in]	associated_data_length		Length of the associated data
- * \param[in]	pAssociated_data			Buffer containing associated data
- * \param[in]	message_length				Length of the message to encrypt
- * \param[in]	pEncrypted_message			Buffer containing the message to decrypt
- * \param[out]	pPlaintext_message			Buffer to store the decrypted message
+ * \param[in] 	pSTSE 							Pointer to STSAFE Handler
+ * \param[in] 	slot_number 					Key slot in symmetric key table to be used
+ * \param[in]	IV_length						IV buffer length in bytes
+ * \param[in]	IV								IV buffer
+ * \param[in]	associated_data_chunk_length	Length of the associated data chunk
+ * \param[in]	pAssociated_data_chunk			Buffer containing associated data chunk
+ * \param[in]	message_chunk_length			Length of the message chunk to decrypt
+ * \param[in]	pEncrypted_message_chunk		Buffer containing the message chunk to decrypt
+ * \param[out]	pPlaintext_message_chunk		Buffer to store the decrypted message chunk
  * \return \ref stse_ReturnCode_t : STSAFE_OK on success ; error code otherwise
  * \details 	\include{doc} stse_aes_gcm_encrypt.dox
  */
@@ -282,57 +282,57 @@ stse_ReturnCode_t stsafea_aes_gcm_decrypt_start(
 		PLAT_UI8 slot_number,
 		PLAT_UI16 IV_length,
 		PLAT_UI8* pIV,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pEncrypted_message,
-		PLAT_UI8 * pPlaintext_message);
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pEncrypted_message_chunk,
+		PLAT_UI8 * pPlaintext_message_chunk);
 
 /**
  * \brief 		Process chunk decryption in AES GCM mode
  * \details 	This service process additional chunk decryption in AES GCM mode using the key specified in start command
- * \param[in] 	pSTSE 						Pointer to STSAFE Handler
- * \param[in]	associated_data_length		Length of the associated data
- * \param[in]	pAssociated_data			Buffer containing associated data
- * \param[in]	message_length				Length of the message to encrypt
- * \param[in]	pEncrypted_message			Buffer containing the message to decrypt
- * \param[out]	pPlaintext_message			Buffer to store the decrypted message
+ * \param[in] 	pSTSE 							Pointer to STSAFE Handler
+ * \param[in]	associated_data_chunk_length	Length of the associated data chunk
+ * \param[in]	pAssociated_data_chunk			Buffer containing associated data chunk
+ * \param[in]	message_chunk_length			Length of the message chunk to decrypt
+ * \param[in]	pEncrypted_message_chunk		Buffer containing the message chunk to decrypt
+ * \param[out]	pPlaintext_message_chunk		Buffer to store the decrypted message chunk
  * \return \ref stse_ReturnCode_t : STSAFE_OK on success ; error code otherwise
  * \details 	\include{doc} stse_aes_gcm_encrypt.dox
  */
 stse_ReturnCode_t stsafea_aes_gcm_decrypt_process(
 		stse_Handler_t * pSTSE,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pEncrypted_message,
-		PLAT_UI8 * pPlaintext_message);
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pEncrypted_message_chunk,
+		PLAT_UI8 * pPlaintext_message_chunk);
 
 /**
  * \brief 		Finish chunk decryption in AES GCM mode
  * \details 	This service finish chunk encryption in AES GCM mode using the key specified in start command
- * \param[in] 	pSTSE 					Pointer to STSAFE Handler
- * \param[in] 	authentication_tag_length	Length of the output authentication tag
- * \param[in]	associated_data_length		Length of the associated data
- * \param[in]	pAssociated_data			Buffer containing associated data
- * \param[in] 	chunk_length 			Length of the chunk
- * \param[in]	pEncrypted_message		Buffer containing the message to decrypt
- * \param[in] 	pAuthentication_tag 	Authentication tag
- * \param[out] 	pVerification_result 	Verification result flag
- * \param[out]	pPlaintext_message		Buffer to store the decrypted message
+ * \param[in] 	pSTSE 							Pointer to STSAFE Handler
+ * \param[in] 	authentication_tag_length		Length of the output authentication tag
+ * \param[in]	associated_data_chunk_length	Length of the associated data chunk
+ * \param[in]	pAssociated_data_chunk			Buffer containing associated data chunk
+ * \param[in]	message_chunk_length			Length of the message chunk to decrypt
+ * \param[in]	pEncrypted_message_chunk		Buffer containing the message chunk to decrypt
+ * \param[in] 	pAuthentication_tag 			Authentication tag
+ * \param[out] 	pVerification_result 			Verification result flag
+ * \param[out]	pPlaintext_message_chunk		Buffer to store the decrypted message chunk
  * \return \ref stse_ReturnCode_t : STSAFE_OK on success ; error code otherwise
  * \details 	\include{doc} stse_aes_gcm_encrypt.dox
  */
 stse_ReturnCode_t stsafea_aes_gcm_decrypt_finish(
 		stse_Handler_t * pSTSE,
 		PLAT_UI8 authentication_tag_length,
-		PLAT_UI16 associated_data_length,
-		PLAT_UI8 * pAssociated_data,
-		PLAT_UI16 message_length,
-		PLAT_UI8 * pEncrypted_message,
+		PLAT_UI16 associated_data_chunk_length,
+		PLAT_UI8 * pAssociated_data_chunk,
+		PLAT_UI16 message_chunk_length,
+		PLAT_UI8 * pEncrypted_message_chunk,
 		PLAT_UI8 * pAuthentication_tag,
 		PLAT_UI8 * pVerification_result,
-		PLAT_UI8 * pPlaintext_message);
+		PLAT_UI8 * pPlaintext_message_chunk);
 
 /** \}*/
 


### PR DESCRIPTION
1. [services] Update comments and functions parameters naming for AES GCM encryption/decryption process by chunk
2. [api] Add function to set symmetric key slot provisioning control fields
3. [core] When debug log activated, add print of status in case of SE return error