### PR TITLE
Fix missing parenthese and complete CONTRIBUTING guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,17 @@ Please note that:
 ## 3. Support requests and questions
 
 For support requests or any other question related to the product, the tools, the environment, you can submit a post to the **ST Community** on the appropriate topic [page](https://community.st.com/s/topiccatalog).
+
+---
+
+### 4. Commit message guidelines
+
+To help maintain a clear history, please format your commit messages using the following convention:
+
+```
+[scope] short summary
+```
+
+- **Scope**: one of the directories or areas affected (e.g. `api/certificate`, `doc`, `git`, `Admin`).
+- **Short summary**: present tense, no trailing period, under 72 characters, starting with a lowercase verb; if related to an opened issue, append `#<number>`
+- **Body**: if necessary, or when the summary exceeds 72 characters, provide additional details explaining the motivation and how this change differs from previous behavior.

--- a/certificate/stse_certificate_crypto.c
+++ b/certificate/stse_certificate_crypto.c
@@ -48,29 +48,29 @@ stse_ReturnCode_t stse_certificate_verify_cert_signature(const stse_certificate_
 		ret = STSE_OK;
 	}
 #ifdef STSE_CONF_USE_COMPANION
-	else if(stsafe_x509_parser_companion_handler != NULL
-	&& stsafe_x509_parser_companion_handler->device_type == STSAFE_A120
+	else if (stsafe_x509_parser_companion_handler != NULL &&
+		 stsafe_x509_parser_companion_handler->device_type == STSAFE_A120
 #ifdef STSE_CONF_HASH_SHA_256
-	&& hash_algo >= STSE_SHA_256
+		 && hash_algo >= STSE_SHA_256
 #endif
-	{ /* Only STSAFE-A120 support Hash features */
+	) { /* Only STSAFE-A120 support Hash features */
 		ret = stse_compute_hash(stsafe_x509_parser_companion_handler, hash_algo,
 					(PLAT_UI8 *)child->tbs, child->tbsSize, digestPtr,
 					(PLAT_UI16 *)&digestSize);
 	}
 #endif
-	else
-	{
+	else {
 		ret = stse_platform_hash_compute(hash_algo, (PLAT_UI8 *)child->tbs, child->tbsSize,
 						 digestPtr, &digestSize);
 	}
 
-	if(ret != STSE_OK)
-	{
+	if (ret != STSE_OK) {
 		return (ret);
 	}
 
-	return(stse_certificate_verify_signature(parent, digestPtr, digestSize, child->Sign.pR, child->Sign.rSize, child->Sign.pS, child->Sign.sSize));
+	return (stse_certificate_verify_signature(parent, digestPtr, digestSize, child->Sign.pR,
+						  child->Sign.rSize, child->Sign.pS,
+						  child->Sign.sSize));
 }
 
 stse_ReturnCode_t stse_certificate_verify_signature(const stse_certificate_t *cert,


### PR DESCRIPTION
This pull request fixes a bug in the handling of the STSE_CONF_USE_COMPANION parameter.

It also adds CONTRIBUTING guidelines for commit messages, which I didn’t find when writing my own commits. I based these on past commits and the Conventional Commits specification, but feel free to provide feedback or adjust them to better align with STMicroelectronics’ standards.