### PR TITLE
[service/stsafea] fix frame transfer communication

### DIFF
--- a/services/stsafea/stsafea_frame_transfer.c
+++ b/services/stsafea/stsafea_frame_transfer.c
@@ -178,12 +178,10 @@ stse_ReturnCode_t stsafea_frame_receive(stse_Handler_t *pSTSE, stse_frame_t *pFr
 
     /* Append filler frame element even if its length equal 0 */
     PLAT_UI8 filler[filler_size];
-    if (filler_size > 0) {
-        stse_frame_element_allocate_push(pFrame,
-                                         eFiller,
-                                         filler_size,
-                                         filler);
-    }
+    stse_frame_element_allocate_push(pFrame,
+                                     eFiller,
+                                     filler_size,
+                                     filler);
 
     /* ======================================================= */
     /* ========= Receive the frame in frame elements ========= */
@@ -296,9 +294,7 @@ stse_ReturnCode_t stsafea_frame_receive(stse_Handler_t *pSTSE, stse_frame_t *pFr
     computed_crc = stse_frame_crc16_compute(pFrame);
 
     /* - Pop Filler element from Frame*/
-    if (filler_size > 0) {
-        stse_frame_pop_element(pFrame);
-    }
+    stse_frame_pop_element(pFrame);
 
     /* - Verify CRC */
     if (computed_crc != *(PLAT_UI16 *)received_crc) {


### PR DESCRIPTION
# Description
This pull request fixes the handling of filler frame elements in the `stsafea_frame_receive` function.  
Previously, filler elements were only appended and popped when their size was greater than zero.  Which does not correspond to the comment above the action `/* Append filler frame element even if its length is equal to 0 */`
This led to inconsistencies in the frame structure, which caused CRC mismatches and initialization errors with the STSafe handler.

The changes in this PR ensure that:
- A filler element is **always appended**, even when its size is zero.
- The filler element is **always popped** after CRC verification.

# Regression
This bug was introduced between **v1.1.1** and **v1.1.2**.  
The previous version (v1.1.1) handled filler frames correctly, but changes in v1.1.2 caused the filler element to be skipped when its length was zero, leading to CRC mismatches.

# Bug Demonstration

## Before the change
The CRC check fails, resulting in error 515:

```
STSAFE Frame >  (4-byte) : { 0x14 } { 0x24 } { 0x9A 0x90 }

STSAFE Frame <  (167-byte) : { 0x00 } { 0x03 } { 0x2D } { 0x00 0x01 }
[00:00:00.902,435]  main: Failed to initialize STSafe handler: 515
```

## After the change
The full frame is received and CRC is validated correctly:

```
STSAFE Frame >  (4-byte) : { 0x14 } { 0x24 } { 0x9A 0x90 }

STSAFE Frame <  (167-byte) : { 0x00 } { 0x03 } { 0x2D } { 0x00 0x01 0x00 0x02 0x01 0x00 0x04 0x01 0x00 0x05 0x01 0x00 0x06 0x01 0x00 0x08 0x00 0x00 0x09 0x01 0x00 0x0A 0x01 0x00 0x0E 0x01 0x00 0x0F 0x01 0x00 0x11 0x01 0x00 0x15 0x01 0x00 0x16 0x01 0x00 0x17 0x01 0x00 0x18 0x01 0x00 0x1A 0x01 0x00 0x1B 0x01 0x00 0x1C 0x01 0x00 0x1F 0x00 0x01 0x00 0x1F 0x01 0x01 0x00 0x1F 0x02 0x01 0x00 0x1F 0x03 0x01 0x00 0x1F 0x04 0x01 0x00 0x1F 0x05 0x01 0x00 0x1F 0x06 0x01 0x00 0x1F 0x07 0x01 0x00 0x1F 0x08 0x01 0x00 0x1F 0x09 0x01 0x00 0x1F 0x0A 0x01 0x00 0x1F 0x0B 0x01 0x00 0x1F 0x0C 0x01 0x00 0x1F 0x0D 0x01 0x00 0x1F 0x0E 0x01 0x00 0x1F 0x0F 0x01 0x00 0x1F 0x10 0x01 0x00 0x1F 0x11 0x01 0x00 0x1F 0x12 0x01 0x00 0x1F 0x13 0x01 0x00 0x1F 0x14 0x01 0x00 0x1F 0x15 0x01 0x00 0x1F 0x16 0x01 0x00 0x1F 0x17 0x01 0x00 0x1F 0x18 0x01 0x00 0x1F 0x19 0x01 0x00 0x1F 0x1A 0x01 0x00 } { 0x63 0x15 }
```

## Edge case: empty frame
The filler is still appended and popped, and CRC is handled correctly:

```
STSAFE Frame >  (4-byte) : { 0x14 } { 0x47 } { 0xCB 0x0D }

STSAFE Frame <  (4-byte) : { 0x00 } { 0x00 } { S } { 0x0F 0x47 }
```

# Impact
- No functional regression expected.  
- Ensures consistent frame parsing logic.  
- Fixes CRC mismatch error (`STSE_CORE_FRAME_CRC_ERROR` / 515).  
- Aligns implementation with the working reference code path.