### PR TITLE
fix(api): stse_data_storage_change_read_access_condition fails due to…

### DIFF
--- a/api/stse_data_storage.h
+++ b/api/stse_data_storage.h
@@ -178,7 +178,7 @@ stse_ReturnCode_t stse_data_storage_change_read_access_condition(
     stse_cmd_protection_t protection);
 
 /*!
- * \brief 		Change the Update access condition of one target STSE device zone and Update de zone with new datas
+ * \brief 		Change the Read access condition and update data of one target STSE device zone
  * \param[in]   pSTSE 		Pointer to target STSE handler
  * \param[in]  	zone 			Target STSE zone index
  * \param[in]	ac				\ref stse_zone_ac_t new access condition

--- a/services/stsafea/stsafea_data_partition.c
+++ b/services/stsafea/stsafea_data_partition.c
@@ -315,7 +315,7 @@ stse_ReturnCode_t stsafea_read_data_zone(stse_Handler_t *pSTSE,
     stse_frame_allocate(RspFrame);
     stse_frame_element_allocate_push(&RspFrame, eRsp_header, STSAFEA_HEADER_SIZE, &rsp_header);
     if (read_length != 0){
-        stse_frame_element_allocate_push(&RspFrame, eData, read_length, (PLAT_UI8 *)pReadBuffer);
+    	stse_frame_element_allocate_push(&RspFrame, eData, read_length, (PLAT_UI8 *)pReadBuffer);
     }
 
     /*- Swap Elements byte order before sending*/


### PR DESCRIPTION
## Description
There is a functional regression or logic error in the  [`stse_data_storage_change_read_access_condition`](https://github.com/STMicroelectronics/STSELib/blob/c196d2304c2759b26bcb15bb5487ec50dcfcf475/api/stse_data_storage.c#L342) function. Currently, this function calls  [`stsafea_read_data_zone`](https://github.com/STMicroelectronics/STSELib/blob/c196d2304c2759b26bcb15bb5487ec50dcfcf475/services/stsafea/stsafea_data_partition.c#L274) with a `read_length` set to `0x00`.

However, `stsafea_read_data_zone` includes a parameter validation check that returns [STSE_SERVICE_INVALID_PARAMETER](https://github.com/STMicroelectronics/STSELib/blob/c196d2304c2759b26bcb15bb5487ec50dcfcf475/services/stsafea/stsafea_data_partition.c#L289) if the length is zero, making it impossible to update the access conditions via this API function.


The current way to update read access condition is :

```c
stsafea_read_option_t read_option = {0};
read_option.new_read_ac = STSE_AC_HOST;
read_option.new_read_ac_change_right = STSE_ACCR_ENABLE;
read_option.change_ac_indicator = STSE_AC_CHANGE;

PLAT_UI8 dummyBuffer[1] = {0};
ret = stsafea_read_data_zone(&stse_handler, zone_id, read_option, 0, dummyBuffer,
			     sizeof(dummyBuffer), STSE_NO_PROT);
```

## After changes
This function now works correctly. 
```c
ret = stse_data_storage_change_read_access_condition(&stse_handler,
							   2,            // zone
							   STSE_AC_HOST, // new access condition
							   STSE_ACCR_ENABLE, // change right
							   STSE_NO_PROT      // protection
);
if (ret != STSE_OK) {
  printk("Failed to update READ AC to HOST: %d\n", ret);
  return -1;
}
```


Thanks @nils-cercariolo-st for advices. This PR closes #61 