### PR TITLE
refactor(core): move session keys to platform secure storage

### DIFF
--- a/core/stse_device.h
+++ b/core/stse_device.h
@@ -161,8 +161,8 @@ struct stse_session_t {
     union {
         struct {
             stse_Handler_t *pSTSE;
-            PLAT_UI8 *pHost_MAC_key;
-            PLAT_UI8 *pHost_cypher_key;
+            PLAT_UI32 Host_MAC_key_idx;
+            PLAT_UI32 Host_cypher_key_idx;
             stse_aes_key_type_t key_type;
             PLAT_UI32 MAC_counter;
         } host;

--- a/core/stse_platform.h
+++ b/core/stse_platform.h
@@ -210,14 +210,33 @@ stse_ReturnCode_t stse_platform_nist_kw_encrypt(PLAT_UI8 *pPayload, PLAT_UI32 pa
 #if defined(STSE_CONF_USE_HOST_KEY_ESTABLISHMENT) || defined(STSE_CONF_USE_SYMMETRIC_KEY_ESTABLISHMENT) || defined(STSE_CONF_USE_HOST_SESSION)
 
 /*!
+ * \brief      Store session key in platform secure storage
+ * \param[in]  pCypherKey Pointer to the cypher key
+ * \param[out] pCypherKeyIdx Pointer to receive the index of the stored cypher key
+ * \param[in]  pMACKey Pointer to the MAC key
+ * \param[out] pMACKeyIdx Pointer to receive the index of the stored MAC key
+ * \param[in]  key_length Length of the keys in bytes
+ * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
+ */
+stse_ReturnCode_t stse_platform_store_session_key(PLAT_UI8 *pCypherKey, PLAT_UI32 *pCypherKeyIdx,
+                                                  PLAT_UI8 *pMACKey, PLAT_UI32 *pMACKeyIdx,
+                                                  PLAT_UI16 key_length);
+
+/*!
+ * \brief      Delete session key from platform secure storage
+ * \param[in]  CypherKeyIdx Index of the cypher key to delete
+ * \param[in]  MACKeyIdx Index of the MAC key to delete
+ * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
+ */
+stse_ReturnCode_t stse_platform_delete_key(PLAT_UI32 CypherKeyIdx, PLAT_UI32 MACKeyIdx);
+
+/*!
  * \brief      Initialize AES CMAC computation
- * \param[in]  pKey Pointer to the key
- * \param[in]  key_length Length of the key
+ * \param[in]  key_idx Index of the key in secure storage
  * \param[in]  exp_tag_size Expected tag size
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_aes_cmac_init(const PLAT_UI8 *pKey,
-                                              PLAT_UI16 key_length,
+stse_ReturnCode_t stse_platform_aes_cmac_init(const PLAT_UI32 key_idx,
                                               PLAT_UI16 exp_tag_size);
 
 /*!
@@ -247,15 +266,14 @@ stse_ReturnCode_t stse_platform_aes_cmac_verify_finish(PLAT_UI8 *pTag);
  * \brief      Perform an AES CMAC encryption
  * \param[in]  pPayload Pointer to Payload
  * \param[in]  payload_length Length of the payload in bytes
- * \param[in]  pKey Pointer to key
- * \param[in]  key_length Length of the key in bytes
+ * \param[in]  key_idx Index of the key in secure storage
  * \param[in]  exp_tag_size Expected tag size in bytes
  * \param[out] pTag Pointer to Tag
  * \param[out] pTag_length Pointer to Tag length value output
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
 stse_ReturnCode_t stse_platform_aes_cmac_compute(const PLAT_UI8 *pPayload, PLAT_UI16 payload_length,
-                                                 const PLAT_UI8 *pKey, PLAT_UI16 key_length,
+                                                 const PLAT_UI32 key_idx,
                                                  PLAT_UI16 exp_tag_size,
                                                  PLAT_UI8 *pTag, PLAT_UI16 *pTag_length);
 
@@ -263,14 +281,13 @@ stse_ReturnCode_t stse_platform_aes_cmac_compute(const PLAT_UI8 *pPayload, PLAT_
  * \brief      Perform an AES CMAC decryption
  * \param[in]  pPayload Pointer to Payload
  * \param[in]  payload_length Length of the payload in bytes
- * \param[in]  pKey Pointer to key
- * \param[in]  key_length Length of the key in bytes
+ * \param[in]  key_idx Index of the key in secure storage
  * \param[in]  pTag Pointer to Tag
  * \param[in]  tag_length Pointer to Tag length value output
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
 stse_ReturnCode_t stse_platform_aes_cmac_verify(const PLAT_UI8 *pPayload, PLAT_UI16 payload_length,
-                                                const PLAT_UI8 *pKey, PLAT_UI16 key_length,
+                                                const PLAT_UI32 key_idx,
                                                 const PLAT_UI8 *pTag, PLAT_UI16 tag_length);
 
 /*!
@@ -278,15 +295,14 @@ stse_ReturnCode_t stse_platform_aes_cmac_verify(const PLAT_UI8 *pPayload, PLAT_U
  * \param[in]  pPlaintext Pointer to the plaintext data
  * \param[in]  plaintext_length Length of the plaintext data
  * \param[in]  pInitial_value Pointer to encryption IV
- * \param[in]  pKey Pointer to the key
- * \param[in]  key_length Length of the key
+ * \param[in]  key_idx Index of the key in secure storage
  * \param[out] pEncryptedtext Pointer to the encrypted payload
  * \param[out] pEncryptedtext_length Length of encrypted payload
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
 stse_ReturnCode_t stse_platform_aes_cbc_enc(const PLAT_UI8 *pPlaintext, PLAT_UI16 plaintext_length,
-                                            PLAT_UI8 *pInitial_value, const PLAT_UI8 *pKey,
-                                            PLAT_UI16 key_length, PLAT_UI8 *pEncryptedtext,
+                                            PLAT_UI8 *pInitial_value, const PLAT_UI32 key_idx,
+                                            PLAT_UI8 *pEncryptedtext,
                                             PLAT_UI16 *pEncryptedtext_length);
 
 /*!
@@ -294,29 +310,27 @@ stse_ReturnCode_t stse_platform_aes_cbc_enc(const PLAT_UI8 *pPlaintext, PLAT_UI1
  * \param[in]  pEncryptedtext Pointer to the encrypted payload
  * \param[in]  encryptedtext_length Length of encrypted payload
  * \param[in]  pInitial_value Pointer to decryption IV
- * \param[in]  pKey Pointer to the key
- * \param[in]  key_length Length of the key
+ * \param[in]  key_idx Index of the key in secure storage
  * \param[out] pPlaintext Pointer to PlainText payload
  * \param[out] pPlaintext_length Length of the PlainText payload
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
 stse_ReturnCode_t stse_platform_aes_cbc_dec(const PLAT_UI8 *pEncryptedtext, PLAT_UI16 encryptedtext_length,
-                                            PLAT_UI8 *pInitial_value, const PLAT_UI8 *pKey,
-                                            PLAT_UI16 key_length, PLAT_UI8 *pPlaintext,
+                                            PLAT_UI8 *pInitial_value, const PLAT_UI32 key_idx,
+                                            PLAT_UI8 *pPlaintext,
                                             PLAT_UI16 *pPlaintext_length);
 
 /*!
  * \brief      Perform an AES ECB encryption
  * \param[in]  pPlaintext Pointer to the plaintext data
  * \param[in]  plaintext_length Length of the plaintext data
- * \param[in]  pKey Pointer to the key
- * \param[in]  key_length Length of the key
+ * \param[in]  key_idx Index of the key in secure storage
  * \param[out] pEncryptedtext Pointer to the encrypted payload
  * \param[out] pEncryptedtext_length Length of encrypted payload
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
 stse_ReturnCode_t stse_platform_aes_ecb_enc(const PLAT_UI8 *pPlaintext, PLAT_UI16 plaintext_length,
-                                            const PLAT_UI8 *pKey, PLAT_UI16 key_length,
+                                            const PLAT_UI32 key_idx,
                                             PLAT_UI8 *pEncryptedtext, PLAT_UI16 *pEncryptedtext_length);
 
 #endif /* defined(STSE_CONF_USE_HOST_KEY_ESTABLISHMENT) || defined(STSE_CONF_USE_SYMMETRIC_KEY_ESTABLISHMENT) || defined(STSE_CONF_USE_HOST_SESSION) */

--- a/services/stsafea/stsafea_sessions.c
+++ b/services/stsafea/stsafea_sessions.c
@@ -96,6 +96,54 @@ stse_ReturnCode_t stsafea_open_host_session(stse_Handler_t *pSTSE, stse_session_
     return (STSE_OK);
 }
 
+stse_ReturnCode_t stsafea_open_host_session_from_idx(stse_Handler_t *pSTSE, stse_session_t *pSession, PLAT_UI32 Host_MAC_key_idx, PLAT_UI32 Host_cypher_key_idx) {
+    stse_ReturnCode_t ret;
+
+    if (pSTSE == NULL) {
+        return STSE_CORE_HANDLER_NOT_INITIALISED;
+    }
+
+    if (pSession == NULL) {
+        return STSE_CORE_SESSION_ERROR;
+    }
+
+    if (pSTSE->device_type == STSAFE_A120) {
+        stsafea_host_key_slot_v2_t host_key_slot;
+
+        ret = stsafea_query_host_key_v2(pSTSE, &host_key_slot);
+        if (ret != STSE_OK) {
+            return ret;
+        }
+
+        if (host_key_slot.key_presence_flag == 0) {
+            return STSE_SERVICE_SESSION_ERROR;
+        }
+        pSession->context.host.key_type = (stse_aes_key_type_t)host_key_slot.key_type;
+        pSession->context.host.MAC_counter = ARRAY_4B_SWAP_TO_UI32(host_key_slot.cmac_sequence_counter);
+    } else {
+        stsafea_host_key_slot_t host_key_slot;
+
+        ret = stsafea_query_host_key(pSTSE, &host_key_slot);
+        if (ret != STSE_OK) {
+            return ret;
+        }
+
+        if (host_key_slot.key_presence_flag == 0) {
+            return STSE_SERVICE_SESSION_ERROR;
+        }
+        pSession->context.host.key_type = STSE_AES_128_KT;
+        pSession->context.host.MAC_counter = ARRAY_3B_SWAP_TO_UI32(host_key_slot.cmac_sequence_counter);
+    }
+
+    pSession->type = STSE_HOST_SESSION;
+    pSession->context.host.Host_MAC_key_idx = Host_MAC_key_idx;
+    pSession->context.host.Host_cypher_key_idx = Host_cypher_key_idx;
+    pSession->context.host.pSTSE = pSTSE;
+    pSTSE->pActive_host_session = pSession;
+
+    return (STSE_OK);
+}
+
 void stsafea_close_host_session(stse_session_t *pSession) {
 
     if (pSession == NULL) {

--- a/services/stsafea/stsafea_sessions.h
+++ b/services/stsafea/stsafea_sessions.h
@@ -39,6 +39,21 @@ stse_ReturnCode_t stsafea_open_host_session(stse_Handler_t *pSTSE,
                                             PLAT_UI8 *pHost_cypher_key);
 
 /*!
+ * \brief 		This Core function Create a session context and associate it to STSAFE handler based on provided key index
+ * \details 	In some configuration, the session keys are already stored in the platform secure storage. This function
+ * allows to open a session based on the key index in the platform secure storage without providing the key value in input.
+ * \param[in] 	*pSession 			\ref stse_session_t Pointer to session
+ * \param[in] 	Host_MAC_key_idx 	Index of the MAC key in the platform secure storage
+ * \param[in] 	Host_cypher_key_idx Index of the cypher key in the platform secure storage
+ * \return \ref STSE_OK on success ; \ref stse_ReturnCode_t error code otherwise
+ * \details 	\include{doc} stsafe_erase_context.dox
+ */
+stse_ReturnCode_t stsafea_open_host_session_from_idx(stse_Handler_t *pSTSE,
+                                                     stse_session_t *pSession,
+                                                     PLAT_UI32 Host_MAC_key_idx,
+                                                     PLAT_UI32 Host_cypher_key_idx);
+
+/*!
  * \brief 		This Core function Close an existing host session context
  * \param[in] 	*pSession 			\ref stse_session_t Pointer to session
  * \return \ref STSE_OK on success ; \ref stse_ReturnCode_t error code otherwise


### PR DESCRIPTION
## Summary
Session keys are no longer kept in RAM. It is now up to the user to decide where they are stored, referencing them via a `uint32_t` key index. 

This improves security, enables backend-agnostic key management, and allows integration with PSA and TrustZone Secure Storage. 

## Changes
- Add secure session key storage via `stse_platform_store_session_key`
- Session now tracks `Host_MAC_key_idx` and `Host_cipher_key_idx`
- Wipe plaintext session keys from RAM after storage
- Use key indices for AES ECB / CBC / CMAC operations

## Security
- Session keys no longer persist in RAM
- Enables hardware-backed key protection

> [!NOTE]
> STSELib remains backend-agnostic (no PSA assumption). The platform decides how keys are stored and used.