### PR TITLE
Add `void *pArg` parm to initialization functions

### DIFF
--- a/api/stse_device_management.c
+++ b/api/stse_device_management.c
@@ -23,7 +23,7 @@
 #define IDLE_BUS_DELAY_MAX 0x1F
 
 /* Exported functions --------------------------------------------------------*/
-stse_ReturnCode_t stse_init(stse_Handler_t *pSTSE) {
+stse_ReturnCode_t stse_init(stse_Handler_t *pSTSE, void *pArg) {
     stse_ReturnCode_t ret = STSE_API_INVALID_PARAMETER;
 
     /* - Check STSAFE handler initialization */
@@ -35,7 +35,7 @@ stse_ReturnCode_t stse_init(stse_Handler_t *pSTSE) {
 #if defined(STSE_CONF_STSAFE_A_SUPPORT) || \
     (defined(STSE_CONF_STSAFE_L_SUPPORT) && defined(STSE_CONF_USE_I2C))
     case STSE_BUS_TYPE_I2C:
-        ret = stse_platform_i2c_init(pSTSE->io.busID);
+        ret = stse_platform_i2c_init(pSTSE->io.busID, pArg);
         if (ret != STSE_OK) {
             return ret;
         }
@@ -43,7 +43,7 @@ stse_ReturnCode_t stse_init(stse_Handler_t *pSTSE) {
 #endif /* STSE_CONF_STSAFE_A_SUPPORT || (STSE_CONF_STSAFE_L_SUPPORT && defined(STSE_CONF_USE_I2C) */
 #ifdef STSE_CONF_USE_ST1WIRE
     case STSE_BUS_TYPE_ST1WIRE:
-        ret = stse_platform_st1wire_init(pSTSE->io.busID);
+        ret = stse_platform_st1wire_init(pSTSE->io.busID, pArg);
         if (ret != STSE_OK) {
             return ret;
         }
@@ -66,23 +66,23 @@ stse_ReturnCode_t stse_init(stse_Handler_t *pSTSE) {
     }
 
     /* - Initialize Host platform */
-    ret = stse_platform_generate_random_init();
+    ret = stse_platform_generate_random_init(pArg);
     if (ret != STSE_OK) {
         return ret;
     }
-    ret = stse_platform_delay_init();
+    ret = stse_platform_delay_init(pArg);
     if (ret != STSE_OK) {
         return ret;
     }
-    ret = stse_platform_power_init();
+    ret = stse_platform_power_init(pArg);
     if (ret != STSE_OK) {
         return ret;
     }
-    ret = stse_platform_crc16_init();
+    ret = stse_platform_crc16_init(pArg);
     if (ret != STSE_OK) {
         return ret;
     }
-    ret = stse_platform_crypto_init();
+    ret = stse_platform_crypto_init(pArg);
     if (ret != STSE_OK) {
         return ret;
     }

--- a/api/stse_device_management.h
+++ b/api/stse_device_management.h
@@ -59,10 +59,11 @@ typedef enum stse_low_power_mode_t {
  * \details 	This function call the handler initialization function from core layer
  *          	to initialize STSE handler in argument
  * \param[in] 	pSTSE 			Pointer to STSE Handler
+ * \param[in]   pArg Argument passed as-is to the `stse_platform_xxx_init()` functions through their `pArg` parameter
  * \return \ref STSE_OK on success ; \ref stse_ReturnCode_t error code otherwise
  * \details 	\include{doc} stse_init.dox
  */
-stse_ReturnCode_t stse_init(stse_Handler_t *pSTSE);
+stse_ReturnCode_t stse_init(stse_Handler_t *pSTSE, void *pArg);
 
 /**
  * \brief 		Reset target device

--- a/core/stse_platform.h
+++ b/core/stse_platform.h
@@ -37,33 +37,38 @@
 
 /*!
  * \brief      Platform delay initialization callback function
+ * \param[in]  pArg Argument coming from \ref stse_init through its `pArg` parameter
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_delay_init(void);
+stse_ReturnCode_t stse_platform_delay_init(void *pArg);
 
 /*!
  * \brief      Platform power control initialization callback function
+ * \param[in]  pArg Argument coming from \ref stse_init through its `pArg` parameter
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_power_init(void);
+stse_ReturnCode_t stse_platform_power_init(void *pArg);
 
 /*!
  * \brief      Platform CRC16 initialization callback function
+ * \param[in]  pArg Argument coming from \ref stse_init through its `pArg` parameter
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_crc16_init(void);
+stse_ReturnCode_t stse_platform_crc16_init(void *pArg);
 
 /*!
  * \brief      Platform crypto library initialization callback function
+ * \param[in]  pArg Argument coming from \ref stse_init through its `pArg` parameter
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_crypto_init(void);
+stse_ReturnCode_t stse_platform_crypto_init(void *pArg);
 
 /*!
  * \brief      Platform random number generation initialization callback function
+ * \param[in]  pArg Argument coming from \ref stse_init through its `pArg` parameter
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_generate_random_init(void);
+stse_ReturnCode_t stse_platform_generate_random_init(void *pArg);
 
 /*!
  * \brief      Platform generate random callback function
@@ -404,9 +409,10 @@ stse_ReturnCode_t stse_platform_power_off(PLAT_UI8 busID, PLAT_UI8 devAddr);
 /*!
  * \brief      Initialize I2C communication
  * \param[in]  busID I2C bus ID
+ * \param[in]  pArg Argument coming from \ref stse_init through its `pArg` parameter
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_i2c_init(PLAT_UI8 busID);
+stse_ReturnCode_t stse_platform_i2c_init(PLAT_UI8 busID, void *pArg);
 
 /*!
  * \brief      Send data over I2C
@@ -551,9 +557,10 @@ stse_ReturnCode_t stse_platform_i2c_receive_stop(
 /*!
  * \brief      Initialize 1-wire communication
  * \param[in]  busID 1-wire bus ID
+ * \param[in]  pArg Argument coming from \ref stse_init through its `pArg` parameter
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */
-stse_ReturnCode_t stse_platform_st1wire_init(PLAT_UI8 busID);
+stse_ReturnCode_t stse_platform_st1wire_init(PLAT_UI8 busID, void *pArg);
 
 /*!
  * \brief      Wake up 1-wire device

--- a/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_crc.c.md
+++ b/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_crc.c.md
@@ -57,7 +57,7 @@ Please find below an extract
  * \brief   Initializes the CRC16 calculation module.
  * \return  STSE_OK on success.
  */
-stse_ReturnCode_t stse_platform_crc16_init(void)
+stse_ReturnCode_t stse_platform_crc16_init(void *pArg)
 {
     crc16_Init();
 

--- a/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_power.c.md
+++ b/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_power.c.md
@@ -57,7 +57,7 @@ Please find below an example of the `stse_platform_power.c` implementation for t
  * \brief   Initializes the power control lines.
  * \return  STSE_OK on success.
  */
-stse_ReturnCode_t stse_platform_power_init (void)
+stse_ReturnCode_t stse_platform_power_init(void *pArg)
 {
     /* -Initialize power line control (PC0  - open-drain) */
     GPIOC->MODER    &=  ~(GPIO_MODER_MODE0_Msk);

--- a/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_random.c.md
+++ b/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_random.c.md
@@ -44,7 +44,7 @@ Please find below an example of the `stse_platform_random.c` implementation for 
  * \brief   Initializes the random number generator.
  * \return  STSE_OK on success.
  */
-stse_ReturnCode_t stse_platform_generate_random_init(void)
+stse_ReturnCode_t stse_platform_generate_random_init(void *pArg)
 {
     rng_start();
 

--- a/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platfrom_crypto_init.c.md
+++ b/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platfrom_crypto_init.c.md
@@ -36,7 +36,7 @@ Please find below an example of the `stse_platform_crypto_init` implementation f
 #include "stselib.h"
 #include "Middleware/STM32_Cryptographic/include/cmox_crypto.h"
 
-stse_ReturnCode_t stse_platform_crypto_init(void)
+stse_ReturnCode_t stse_platform_crypto_init(void *pArg)
 {
     stse_ReturnCode_t ret = STSE_OK;
 

--- a/doc/resources/dox_files/APIs/device_management/stse_device_power_on.dox
+++ b/doc/resources/dox_files/APIs/device_management/stse_device_power_on.dox
@@ -35,7 +35,7 @@ int main (void)
     stse_handler.io.Busaddr = 1;
 	stsafe_handler.io.PowerLineOn  = power_on;
 	stsafe_handler.io.PowerLineOff = power_off;
-    stse_ret = stse_init(&stse_handler);
+    stse_ret = stse_init(&stse_handler, NULL);
     if (stse_ret != STSE_OK)
     {
         /* Handle Error */

--- a/doc/resources/dox_files/APIs/device_management/stse_init.dox
+++ b/doc/resources/dox_files/APIs/device_management/stse_init.dox
@@ -52,7 +52,7 @@ Following diagram illustrates the interactions performed between the Host and th
     }
     stse_handler.device_type = STSAFE_A120;
     stse_handler.io.Busaddr = 1;
-    stse_ret = stse_init(&stse_handler);
+    stse_ret = stse_init(&stse_handler, NULL);
     if (stse_ret != STSE_OK)
     {
         /* Handle Error */


### PR DESCRIPTION
Allows users to pass a generic argument (`void *pArg`) to `stse_init()`, which forwards it to the `stse_platform_xxx_init()` functions. This enables the porting layer to perform custom initialization based on the argument's content.