### PR TITLE
fix(stse_generate_random): fix overflow and improve documentation

### DIFF
--- a/api/stse_random.c
+++ b/api/stse_random.c
@@ -30,6 +30,10 @@ stse_ReturnCode_t stse_generate_random(
         return (STSE_API_HANDLER_NOT_INITIALISED);
     }
 
+    if (random_size == 0) {
+        return (STSE_OK);
+    }
+
     if (pRandom == NULL) {
         return (STSE_API_INVALID_PARAMETER);
     }
@@ -38,17 +42,18 @@ stse_ReturnCode_t stse_generate_random(
 #ifdef STSE_CONF_STSAFE_L_SUPPORT
     if (pSTSE->device_type != STSAFE_L010) {
 #endif /* STSE_CONF_STSAFE_L_SUPPORT */
-        for (PLAT_UI16 index = 0; index < random_size;) {
-            ret = stsafea_generate_random(
-                pSTSE,
-                &pRandom[index],
-                ((random_size - index) < STSAFEA_MAXIMUM_RNG_SIZE) ? (random_size - index) : STSAFEA_MAXIMUM_RNG_SIZE);
+        while (0 < random_size) {
+            PLAT_UI16 chunk = (random_size < STSAFEA_MAXIMUM_RNG_SIZE) ? 
+                            random_size : STSAFEA_MAXIMUM_RNG_SIZE;
+
+            ret = stsafea_generate_random(pSTSE, pRandom, chunk);
 
             if (ret != STSE_OK) {
                 break;
             }
 
-            index += STSAFEA_MAXIMUM_RNG_SIZE;
+            random_size -= chunk;
+            pRandom += chunk;
         }
 #ifdef STSE_CONF_STSAFE_L_SUPPORT
     }

--- a/api/stse_random.h
+++ b/api/stse_random.h
@@ -33,7 +33,7 @@
  * \details 		This API use the STSE to generate random number
  * \param[in]		pSTSE 			Pointer to target STSecureElement device
  * \param[in,out] 	pRandom 		Pointer to random buffer
- * \param[in,out] 	random_size 	Random size
+ * \param[in]       random_size 	Random size
  * \return 			\ref STSE_OK on success ; \ref stse_ReturnCode_t error code otherwise
  */
 stse_ReturnCode_t stse_generate_random(


### PR DESCRIPTION
## Changes

### Bug fix
The previous implementation incremented the index by `STSAFEA_MAXIMUM_RNG_SIZE` even for the last chunk, which could cause an integer overflow and potentially an infinite loop when `random_size` is close to `UINT16_MAX`.

Replaced index-based iteration with pointer arithmetic and `random_size` decrement to avoid overflow. Added early return `STSE_OK` for `random_size == 0`.

### Documentation
Fixed incorrect Doxygen tag for `random_size` parameter from `[in,out]` to `[in]`.