### PR TITLE
[refactor][core - platform] replace printf() calls with stse_platform_printf()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API change** — all platform-level SecureElement initialization functions now require an additional `void *pArg` parameter ([51aa3f8](https://github.com/STMicroelectronics/STSELib/commit/51aa3f8114d33adfe38da6fd261e4b9a71a1fa9b))
 - **Platform AES API change** — all platform AES cryptographic functions now reference keys by secure storage index (`PLAT_UI32 key_idx`) instead of raw key pointer and length (`PLAT_UI8 *pKey, PLAT_UI16 key_length`). Affected functions: `stse_platform_aes_cmac_init`, `stse_platform_aes_cmac_compute`, `stse_platform_aes_cmac_verify`, `stse_platform_aes_cbc_enc`, `stse_platform_aes_cbc_dec`, `stse_platform_aes_ecb_enc`
 - **Renamed** `stsafea_open_host_session` to `stsafea_open_host_session_from_idx` — signature updated to accept key indices (`PLAT_UI32 host_MAC_key_idx`, `PLAT_UI32 host_cypher_key_idx`) instead of raw key pointers
+- **printf() calls replaced** with `stse_platform_printf()` in all library code to abstract away standard I/O and allow platform-specific implementations for logging and output
 
 ### Added
 
 - `stse_platform_store_aes_key()` — new platform function to store an AES key into platform secure storage and retrieve its index
 - `stse_platform_delete_aes_key()` — new platform function to delete an AES key from platform secure storage by index
+- `stse_platform_printf()` — new platform function for formatted output, replacing all direct calls to `printf()` in the library with this abstraction to allow platform-specific implementations and avoid direct use of standard I/O in library code
 
 ### Changed
 

--- a/core/stse_frame.c
+++ b/core/stse_frame.c
@@ -164,25 +164,25 @@ void stse_frame_debug_print(stse_frame_t *pFrame) {
     PLAT_UI16 data_index;
 
     if (pFrame->element_count == 0) {
-        printf("\n\r (EMPTY)");
+        stse_platform_printf("\n\r (EMPTY)");
         return;
     }
     pCurrent_element = pFrame->first_element;
-    printf(" (%d-byte) :", pFrame->length);
+    stse_platform_printf(" (%d-byte) :", pFrame->length);
     do {
-        printf(" { ");
+        stse_platform_printf(" { ");
         if (pCurrent_element->length == 0) {
-            printf("S ");
+            stse_platform_printf("S ");
         } else {
             for (data_index = 0; data_index < pCurrent_element->length; data_index++) {
                 if (pCurrent_element->pData != NULL) {
-                    printf("0x%02X ", pCurrent_element->pData[data_index]);
+                    stse_platform_printf("0x%02X ", pCurrent_element->pData[data_index]);
                 } else {
-                    printf("0x00 ");
+                    stse_platform_printf("0x00 ");
                 }
             }
         }
-        printf("}");
+        stse_platform_printf("}");
         pCurrent_element = pCurrent_element->next;
     } while (pCurrent_element != NULL);
 }

--- a/core/stse_platform.h
+++ b/core/stse_platform.h
@@ -71,6 +71,11 @@ stse_ReturnCode_t stse_platform_crypto_init(void *pArg);
 stse_ReturnCode_t stse_platform_generate_random_init(void *pArg);
 
 /*!
+ * \brief      Platform log abstraction
+ */
+void stse_platform_printf(const char *format, ...);
+
+/*!
  * \brief      Platform generate random callback function
  * \return     \ref STSE_OK on success; \ref stse_ReturnCode_t error code otherwise
  */

--- a/doc/resources/Markdown/04_PORTING_GUIDE/03_PORTINNG_GUIDE.md
+++ b/doc/resources/Markdown/04_PORTING_GUIDE/03_PORTINNG_GUIDE.md
@@ -41,6 +41,7 @@ Following platform files architecture are recommended to simplify the porting of
 - @subpage stse_platform_power
 - @subpage stse_platform_i2c
 - @subpage stse_platform_st1wire
+- @subpage stse_platform_log
 
 # Reference Implementations
 

--- a/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_log.c.md
+++ b/doc/resources/Markdown/04_PORTING_GUIDE/PAL_files/stse_platform_log.c.md
@@ -1,0 +1,25 @@
+# stse_platform_log.c {#stse_platform_log}
+
+The `stse_platform_log.c` file provides string formatting and logging functions for the STSE library, abstracting the platform-specific details of standard output and debugging streams in order to don't be `stdio`-dependent and allow platform-specific implementations for logging and output.
+
+## stse_platform_printf:
+- **Purpose**: Provides a platform abstraction for formatted output, replacing all direct calls to `printf()` in the library with this function to allow platform-specific implementations and avoid direct use of standard I/O in library code.
+- **Parameters**: Accepts a format string and a variable number of arguments, similar to the standard `printf()` function.
+- **Return Value**: return void
+
+## Implementation example:
+
+```c
+#include "stselib.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+
+void stse_platform_printf(const char *format, ...) {
+    va_list args;
+    
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+}
+```

--- a/services/stsafea/stsafea_frame_transfer.c
+++ b/services/stsafea/stsafea_frame_transfer.c
@@ -72,9 +72,9 @@ stse_ReturnCode_t stsafea_frame_transmit(stse_Handle_t *pSTSE, stse_frame_t *pFr
     stse_frame_push_element(pFrame, &crc_element);
 
 #ifdef STSE_FRAME_DEBUG_LOG
-    printf("\n\r STSAFE Frame > ");
+    stse_platform_printf("\n\r STSAFE Frame > ");
     stse_frame_debug_print(pFrame);
-    printf("\n\r");
+    stse_platform_printf("\n\r");
 #endif /* STSE_FRAME_DEBUG_LOG */
 
     ret = STSE_PLATFORM_BUS_ACK_ERROR;
@@ -223,11 +223,11 @@ stse_ReturnCode_t stsafea_frame_receive(stse_Handle_t *pSTSE, stse_frame_t *pFra
         computed_crc = stse_platform_Crc16_Calculate(&received_header, STSE_RSP_FRAME_HEADER_SIZE);
 
 #ifdef STSE_FRAME_DEBUG_LOG
-        printf("\n\r STSAFE Frame <  (%d-byte) : { 0x%02X } { 0x%02X 0x%02X }\n\r",
-               received_length + STSE_FRAME_CRC_SIZE,
-               received_header,
-               received_crc[0],
-               received_crc[1]);
+        stse_platform_printf("\n\r STSAFE Frame <  (%d-byte) : { 0x%02X } { 0x%02X 0x%02X }\n\r",
+                             received_length + STSE_FRAME_CRC_SIZE,
+                             received_header,
+                             received_crc[0],
+                             received_crc[1]);
 #endif /* STSE_FRAME_DEBUG_LOG */
 
         /* - Verify CRC */
@@ -367,9 +367,9 @@ stse_ReturnCode_t stsafea_frame_receive(stse_Handle_t *pSTSE, stse_frame_t *pFra
         }
 
 #ifdef STSE_FRAME_DEBUG_LOG
-        printf("\n\r STSAFE Frame < ");
+        stse_platform_printf("\n\r STSAFE Frame < ");
         stse_frame_debug_print(pFrame);
-        printf("\n\r");
+        stse_platform_printf("\n\r");
 #endif /* STSE_FRAME_DEBUG_LOG */
 
         /* - Swap CRC */


### PR DESCRIPTION
Currently, the STSELib is `stdio`-dependent, which is not permitted with some usage like TF-M. The introduction of this PAL should make the lib less platform-dependent. 