### PR TITLE
[refactor][api] simplify `stse_get_ecc_key_type_from_curve_id()` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Platform AES API change** — all platform AES cryptographic functions now reference keys by secure storage index (`PLAT_UI32 key_idx`) instead of raw key pointer and length (`PLAT_UI8 *pKey, PLAT_UI16 key_length`). Affected functions: `stse_platform_aes_cmac_init`, `stse_platform_aes_cmac_compute`, `stse_platform_aes_cmac_verify`, `stse_platform_aes_cbc_enc`, `stse_platform_aes_cbc_dec`, `stse_platform_aes_ecb_enc`
 - **Renamed** `stsafea_open_host_session` to `stsafea_open_host_session_from_idx` — signature updated to accept key indices (`PLAT_UI32 host_MAC_key_idx`, `PLAT_UI32 host_cypher_key_idx`) instead of raw key pointers
 - **printf() calls replaced** with `stse_platform_printf()` in all library code to abstract away standard I/O and allow platform-specific implementations for logging and output
+- **API change** — `stse_get_ecc_key_type_from_curve_id` now returns the resolved `stse_ecc_key_type_t` directly (or `STSE_ECC_KT_INVALID` if unknown) and takes a single packed `stsafea_ecc_curve_id_t` pointer, replacing the previous `PLAT_UI8 curve_id_length`, `const PLAT_UI8 *pCurve_id_value` and `stse_ecc_key_type_t *pKey_type` parameters
 
 ### Added
 

--- a/core/stse_generic_typedef.c
+++ b/core/stse_generic_typedef.c
@@ -116,28 +116,22 @@ const stse_ecc_info_t stse_ecc_info_table[] =
     defined(STSE_CONF_ECC_BRAINPOOL_P_256) || defined(STSE_CONF_ECC_BRAINPOOL_P_384) || defined(STSE_CONF_ECC_BRAINPOOL_P_512) || \
     defined(STSE_CONF_ECC_CURVE_25519) || defined(STSE_CONF_ECC_EDWARD_25519)
 
-stse_ReturnCode_t stse_get_ecc_key_type_from_curve_id(
-    PLAT_UI8 curve_id_length,
-    const PLAT_UI8 *pCurve_id_value,
-    stse_ecc_key_type_t *pKey_type) {
-    stse_ReturnCode_t ret = STSE_OK;
-    stse_ecc_key_type_t key_type;
+stse_ecc_key_type_t stse_get_ecc_key_type_from_curve_id(const stsafea_ecc_curve_id_t curve_id[static 1]) {
+    stse_ecc_key_type_t key_type = (stse_ecc_key_type_t)0;
 
-    for (key_type = (stse_ecc_key_type_t)0; (PLAT_I8)key_type < (PLAT_I8)STSE_ECC_KT_INVALID;) {
-        PLAT_UI8 info_curve_id_length = stse_ecc_info_table[key_type].curve_id_total_length - STSE_ECC_GENERIC_LENGTH_SIZE;
-        if (curve_id_length == info_curve_id_length) {
-            if (memcmp(stse_ecc_info_table[key_type].curve_id.value,
-                       pCurve_id_value,
-                       info_curve_id_length) == 0) {
-                break;
-            }
+    // Compare slot curve ID against each known curve ID
+    while (key_type < STSE_ECC_KT_INVALID) {
+        /* The curve id is compared byte-for-byte with memcmp. This is valid because
+         * stsafea_ecc_curve_id_t is a packed struct (PLAT_PACKED_STRUCT): its `length` and `value`
+         * fields sit contiguously with no padding, so the first curve_id_total_length bytes are
+         * exactly the curve-id byte sequence, with no padding bytes to cause a spurious mismatch. */
+        if (memcmp(&(stse_ecc_info_table[key_type].curve_id), curve_id, stse_ecc_info_table[key_type].curve_id_total_length) == 0) {
+            break;
         }
         key_type++;
     }
 
-    *pKey_type = key_type;
-
-    return ret;
+    return key_type;
 }
 
 #endif

--- a/core/stse_generic_typedef.c
+++ b/core/stse_generic_typedef.c
@@ -112,10 +112,6 @@ const stse_ecc_info_t stse_ecc_info_table[] =
 };
 #endif
 
-#if defined(STSE_CONF_ECC_NIST_P_256) || defined(STSE_CONF_ECC_NIST_P_384) || defined(STSE_CONF_ECC_NIST_P_521) ||                \
-    defined(STSE_CONF_ECC_BRAINPOOL_P_256) || defined(STSE_CONF_ECC_BRAINPOOL_P_384) || defined(STSE_CONF_ECC_BRAINPOOL_P_512) || \
-    defined(STSE_CONF_ECC_CURVE_25519) || defined(STSE_CONF_ECC_EDWARD_25519)
-
 stse_ecc_key_type_t stse_get_ecc_key_type_from_curve_id(const stsafea_ecc_curve_id_t curve_id[static 1]) {
     stse_ecc_key_type_t key_type = (stse_ecc_key_type_t)0;
 
@@ -132,6 +128,5 @@ stse_ecc_key_type_t stse_get_ecc_key_type_from_curve_id(const stsafea_ecc_curve_
     }
 
     return key_type;
-}
 
 #endif

--- a/core/stse_generic_typedef.h
+++ b/core/stse_generic_typedef.h
@@ -589,10 +589,6 @@ typedef struct {
 
 extern const stse_ecc_info_t stse_ecc_info_table[];
 
-#if defined(STSE_CONF_ECC_NIST_P_256) || defined(STSE_CONF_ECC_NIST_P_384) || defined(STSE_CONF_ECC_NIST_P_521) ||                \
-    defined(STSE_CONF_ECC_BRAINPOOL_P_256) || defined(STSE_CONF_ECC_BRAINPOOL_P_384) || defined(STSE_CONF_ECC_BRAINPOOL_P_512) || \
-    defined(STSE_CONF_ECC_CURVE_25519) || defined(STSE_CONF_ECC_EDWARD_25519)
-
 /**
  * \brief 		Get ECC key type from curve identifier
  * \details 	This function resolves the ECC key type from a given curve identifier by
@@ -602,8 +598,6 @@ extern const stse_ecc_info_t stse_ecc_info_table[];
  * 				\ref STSE_ECC_KT_INVALID if the curve identifier is not recognized
  */
 stse_ecc_key_type_t stse_get_ecc_key_type_from_curve_id(const stsafea_ecc_curve_id_t curve_id[static 1]);
-
-#endif
 
 /** \}*/
 

--- a/core/stse_generic_typedef.h
+++ b/core/stse_generic_typedef.h
@@ -595,16 +595,13 @@ extern const stse_ecc_info_t stse_ecc_info_table[];
 
 /**
  * \brief 		Get ECC key type from curve identifier
- * \details 	This function resolves the ECC key type from a given curve identifier value
- * \param[in]	curve_id_length		Length of the curve identifier
- * \param[in]	pCurve_id_value		Pointer to the curve identifier value
- * \param[out]	pKey_type			Pointer to store the resolved ECC key type
- * \return 		\ref STSE_OK on success ; \ref stse_ReturnCode_t error code otherwise
+ * \details 	This function resolves the ECC key type from a given curve identifier by
+ * 				comparing it against each entry of \ref stse_ecc_info_table.
+ * \param[in]	curve_id	Pointer to the curve identifier (length + value) to resolve
+ * \return 		The matching \ref stse_ecc_key_type_t ;
+ * 				\ref STSE_ECC_KT_INVALID if the curve identifier is not recognized
  */
-stse_ReturnCode_t stse_get_ecc_key_type_from_curve_id(
-    PLAT_UI8 curve_id_length,
-    const PLAT_UI8 *pCurve_id_value,
-    stse_ecc_key_type_t *pKey_type);
+stse_ecc_key_type_t stse_get_ecc_key_type_from_curve_id(const stsafea_ecc_curve_id_t curve_id[static 1]);
 
 #endif
 


### PR DESCRIPTION
# Summary
Reworks `stse_get_ecc_key_type_from_curve_id()`:
- **New signature**: returns the resolved `stse_ecc_key_type_t` directly (or `STSE_ECC_KT_INVALID` if the curve is unknown) and takes a single packed `stsafea_ecc_curve_id_t` pointer, instead of the previous three parameters (`PLAT_UI8 curve_id_length`, `const PLAT_UI8 *pCurve_id_value`, `stse_ecc_key_type_t *pKey_type output`).
- **Guards removed**: the `#if defined(STSE_CONF_ECC_*)` conditional-compilation blocks around the declaration and definition are dropped; the function is now always available.


# Why this change
1. Direct interoperability with the slot-info API.
The curve identifier returned by `stse_get_ecc_key_slot_info()`, the `curve_id` field of `stsafea_private_key_slot_information_t`, is already a `stsafea_ecc_curve_id_t`. With the old signature the caller had to manually unpack it into a scalar length (length is a 2-byte array) and a value pointer before resolving the key type. The new signature lets that output be passed straight through: 
- Before:
  ```c
  stsafea_private_key_slot_information_t slot_info;
  stse_ecc_key_type_t key_type;
  PLAT_UI16 global_usage_limit;
  
  stse_get_ecc_key_slot_info(pSTSE, slot_number, &global_usage_limit, &slot_info);
  
  /* length is a 2-byte (big-endian) field, had to be reduced to a scalar
   * and split from the value before resolving the key type */
  PLAT_UI8 curve_id_length = slot_info.curve_id.length[1];
  stse_ReturnCode_t ret = stse_get_ecc_key_type_from_curve_id(
      curve_id_length,
      slot_info.curve_id.value,
      &key_type);
  
  if (ret == STSE_OK) {
      /* No point performing this check, because stse_get_ecc_key_type_from_curve_id() 
       * always return STSE_OK */
  }
  
  if (key_type == STSE_ECC_KT_INVALID) {
      /* unrecognized curve */
  }
  ```
- After
  ```c
  stsafea_private_key_slot_information_t slot_info;
  PLAT_UI16 global_usage_limit;
  
  stse_get_ecc_key_slot_info(pSTSE, slot_number, &global_usage_limit, &slot_info);
  
  /* the slot's curve_id can be passed directly */
  stse_ecc_key_type_t key_type = stse_get_ecc_key_type_from_curve_id(&slot_info.curve_id);
  
  if (key_type == STSE_ECC_KT_INVALID) {
      /* unrecognized curve */
  }
  ```
2. A clearer, less error-prone contract.
The function never had a real failure path, it always returned `STSE_OK` and signalled "not found" through `*pKey_type == STSE_ECC_KT_INVALID`. Returning the key type directly makes that the single, obvious result value and removes the redundant output pointer and return-code plumbing. The `[static 1]` array parameter also documents (and, on supporting compilers, enforces) that a non-null pointer is required.

3. Removing the config guards.
Guarding the symbol behind `STSE_CONF_ECC_*` made its availability depend on which curves happen to be enabled, so any generic caller had to replicate the same long `#if defined(...)` condition to avoid link errors. Since the function only reads `stse_ecc_info_table` and safely returns `STSE_ECC_KT_INVALID` when no curve matches, there is no reason to compile it out. Exposing it unconditionally gives callers a stable API surface.

# Notes
- The byte-for-byte `memcmp` over the packed struct is safe because `stsafea_ecc_curve_id_t` is a `PLAT_PACKED_STRUCT` (no padding between `length` and `value`); this is now documented with an inline comment.
- Doxygen documentation and `CHANGELOG.md` updated to match the new signature.

⚠️ Breaking change: existing callers must be updated to the new signature.

