### PR TITLE
Fix DER TLV length parse when reading certificate size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `stse_get_device_certificate_size()` now decodes the X.509 DER TLV header instead of assuming a fixed 2-byte length field, correctly sizing certificates that use the short form or a 1-byte long-form length. Invalid or corrupted certificates are now detected and rejected (non-`SEQUENCE` tag, forbidden indefinite length, non-minimal or zero length, sizes exceeding the 16-bit output) returning `STSE_CERT_UNEXPECTED_SEQUENCE` / `STSE_CERT_INVALID_CERTIFICATE` instead of a wrong size.
+- `stse_device_authenticate()` now reuses `stse_get_device_certificate_size()` to determine the certificate size instead of duplicating the inline 2-byte length computation, so it benefits from the corrected DER TLV parsing and the malformed-certificate validation.
 
 ### Security
 - AES keys are now securely stored in platform secure storage and referenced by index, eliminating the need to handle raw key material in application memory and enhancing overall security.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `stsafea_host_keys_t` type.
 
 ### Fixed
+- `stse_get_device_certificate_size()` now decodes the X.509 DER TLV header instead of assuming a fixed 2-byte length field, correctly sizing certificates that use the short form or a 1-byte long-form length. Invalid or corrupted certificates are now detected and rejected (non-`SEQUENCE` tag, forbidden indefinite length, non-minimal or zero length, sizes exceeding the 16-bit output) returning `STSE_CERT_UNEXPECTED_SEQUENCE` / `STSE_CERT_INVALID_CERTIFICATE` instead of a wrong size.
 
 ### Security
 - AES keys are now securely stored in platform secure storage and referenced by index, eliminating the need to handle raw key material in application memory and enhancing overall security.

--- a/api/stse_device_authentication.c
+++ b/api/stse_device_authentication.c
@@ -27,8 +27,6 @@
 #include "certificate/stse_certificate_subparsing.h"
 #include "certificate/stse_certificate_types.h"
 
-#define STSE_CERTIFICATE_SIZE_OFFSET_BYTES 2U
-#define STSE_CERTIFICATE_SIZE_LENGTH 2U
 #define STSE_CERTIFICATE_OFFSET_BYTES 0U
 #define STSE_CERTIFICATE_DEVICE_ID_OFFSET 15U
 #define STSE_CERTIFICATE_DEVICE_ID_SIZE 11U
@@ -174,7 +172,6 @@ stse_ReturnCode_t stse_device_authenticate(
     stse_ReturnCode_t ret;
     stse_certificate_t leaf_certificate;
     PLAT_UI16 certificate_size;
-    PLAT_UI8 certificate_size_ui8[2];
 
     if (pSTSE == NULL) {
         return (STSE_API_HANDLER_NOT_INITIALISED);
@@ -184,20 +181,11 @@ stse_ReturnCode_t stse_device_authenticate(
         return (STSE_API_INVALID_PARAMETER);
     }
 
-    ret = stse_data_storage_read_data_zone(
-        pSTSE,
-        certificate_zone,
-        STSE_CERTIFICATE_SIZE_OFFSET_BYTES, /* 2 bytes offset */
-        certificate_size_ui8,               /* Returned certificate size */
-        STSE_CERTIFICATE_SIZE_LENGTH,       /* Certificate size length 2 bytes */
-        0,                                  /* No maximum chunk size (No chunk at all) */
-        STSE_NO_PROT);                      /* No protection */
+    ret = stse_get_device_certificate_size(pSTSE, certificate_zone, &certificate_size);
 
     if (ret != STSE_OK) {
         return ret;
     }
-
-    certificate_size = (((uint16_t)certificate_size_ui8[0]) << 8) + ((uint16_t)certificate_size_ui8[1]) + 4U;
 
     PLAT_UI8 certificate[certificate_size];
 

--- a/api/stse_device_authentication.c
+++ b/api/stse_device_authentication.c
@@ -17,6 +17,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include <stddef.h>
+#include <stdint.h>
 
 #include "api/stse_device_authentication.h"
 #include "api/stse_ecc.h"
@@ -24,6 +25,7 @@
 #include "certificate/stse_certificate.h"
 #include "certificate/stse_certificate_crypto.h"
 #include "certificate/stse_certificate_subparsing.h"
+#include "certificate/stse_certificate_types.h"
 
 #define STSE_CERTIFICATE_SIZE_OFFSET_BYTES 2U
 #define STSE_CERTIFICATE_SIZE_LENGTH 2U
@@ -57,7 +59,7 @@ stse_ReturnCode_t stse_get_device_id(stse_Handle_t *pSTSE, PLAT_UI8 certificate_
 
 stse_ReturnCode_t stse_get_device_certificate_size(stse_Handle_t *pSTSE, PLAT_UI8 certificate_zone, PLAT_UI16 *pCertificate_size) {
     volatile stse_ReturnCode_t ret = STSE_API_INVALID_PARAMETER;
-    PLAT_UI8 certificate_size_ui8[2];
+    PLAT_UI8 tlv_header[4];
 
     /* - Check stsafe handler initialization */
     if (pSTSE == NULL) {
@@ -69,19 +71,69 @@ stse_ReturnCode_t stse_get_device_certificate_size(stse_Handle_t *pSTSE, PLAT_UI
     }
 
     ret = stse_data_storage_read_data_zone(
-        pSTSE,                              /* STSE handler */
-        certificate_zone,                   /* Certificate zone */
-        STSE_CERTIFICATE_SIZE_OFFSET_BYTES, /* 2 bytes offset */
-        certificate_size_ui8,               /* Returned certificate size */
-        STSE_CERTIFICATE_SIZE_LENGTH,       /* Certificate size length 2 bytes */
-        0,                                  /* No maximum chunk size (No chunk at all) */
-        STSE_NO_PROT);                      /* No protection */
+        pSTSE,              /* STSE handler */
+        certificate_zone,   /* Certificate zone */
+        0,                  /* No offset */
+        tlv_header,         /* Returned TLV header (tag + length bytes) */
+        sizeof(tlv_header), /* TLV header length 4 bytes */
+        0,                  /* No maximum chunk size (No chunk at all) */
+        STSE_NO_PROT);      /* No protection */
 
     if (ret != STSE_OK) {
         return ret;
     }
 
-    *pCertificate_size = (((uint16_t)certificate_size_ui8[0]) << 8) + ((uint16_t)certificate_size_ui8[1]) + 4U;
+    if (tlv_header[0] != TAG_SEQUENCE) {
+        /* Invalid X.509 DER certificate: the TAG is not SEQUENCE (0x30) */
+        return STSE_CERT_UNEXPECTED_SEQUENCE;
+    }
+
+    if (tlv_header[1] == 0x80) {
+        /* Invalid X.509 DER certificate: the indefinite length is not allowed in DER (it would also
+         * decode to len_of_len == 0, clashing with the short-form case below) */
+        return STSE_CERT_INVALID_CERTIFICATE;
+    }
+
+    /* The second byte encodes the Value length: below 0x80 it is the length itself (short form, no
+     * extra length bytes); otherwise bit 7 flags the long form and the low 7 bits tell how many of
+     * the following bytes encode the length (e.g. 0x82 means the next 2) */
+    PLAT_UI8 len_of_len = (tlv_header[1] < 0x80) ? 0 : (tlv_header[1] & ~0x80);
+
+    /* Decode the Value length and the smallest length the used encoding is allowed to carry:
+     * a certificate cannot be empty and DER requires the minimal length encoding */
+    PLAT_UI16 min_size;
+    switch (len_of_len) {
+        case 0:
+            *pCertificate_size = tlv_header[1];
+            min_size = 1;     // 1 byte
+            break;
+        case 1:
+            *pCertificate_size = tlv_header[2];
+            min_size = 0x80;  // 128 bytes
+            break;
+        case 2:
+            *pCertificate_size = (tlv_header[2] << 8) | tlv_header[3];
+            min_size = 0x100; // 256 bytes
+            break;
+        default:
+            /* Unsupported X.509 DER certificate: a length field longer than 2 bytes means a
+             * certificate larger than 65535 bytes, beyond what *pCertificate_size can represent */
+            return STSE_CERT_INVALID_CERTIFICATE;
+    }
+
+    if (*pCertificate_size < min_size) {
+        /* Invalid X.509 DER certificate: the length is zero or not minimally encoded */
+        return STSE_CERT_INVALID_CERTIFICATE;
+    }
+
+    /* Size of the Tag+Length field: tag byte + first length byte + extra length bytes.
+     * The parsed length covers the Value only, so add this to get the whole size */
+    PLAT_UI8 tl_len = 2 + len_of_len;
+    if (*pCertificate_size > UINT16_MAX - tl_len) {
+        /* Invalid X.509 DER certificate: the total size overflows 16 bits */
+        return STSE_CERT_INVALID_CERTIFICATE;
+    }
+    *pCertificate_size += tl_len;
 
     return STSE_OK;
 }


### PR DESCRIPTION
# Summary
`stse_get_device_certificate_size()` read a fixed 2-byte length at offset 2 and added a hard-coded `4`. That only works for the DER long-form-with-2-length-bytes encoding, and it did **no validation** of the zone content, any two bytes were blindly used as a length.

  This MR properly decodes the X.509 **DER TLV** header and now **detects and rejects invalid or corrupted certificates** instead of returning a wrong size: non-`SEQUENCE` tag (empty/unprovisioned zone), forbidden indefinite length (`0x80`), non-minimal or zero length, and sizes too large for the 16-bit output. These fail early with `STSE_CERT_UNEXPECTED_SEQUENCE` / `STSE_CERT_INVALID_CERTIFICATE`.

# What changed
- Read the first **4 bytes** (tag + up to 3 length bytes) instead of only the 2 length bytes at offset 2.
- Decode the length according to DER rules:
  - verify the tag is `SEQUENCE` (`0x30`);
  - reject the indefinite length (`0x80`), not allowed in DER;
  - handle short form and 1-/2-byte long form to obtain the Value length;
  - add the Tag+Length field size to return the **full** certificate size.
- Harden against malformed input:
  - enforce **minimal** DER length encoding;
  - reject empty / zero-length certificates;
  - reject length fields longer than 2 bytes (> 65535, beyond `PLAT_UI16`);
  - guard the final addition against **16-bit overflow**.
- Add `<stdint.h>` (`UINT16_MAX`) and `certificate/stse_certificate_types.h` (`TAG_SEQUENCE`) includes.

# Why
The previous code returned a wrong size for any certificate not encoded with a 2-byte long-form length, and did no validation of the DER header, a malformed or unexpected zone content could produce a bogus size used by callers to allocate/read the certificate.

# Impact
No API change. Return values are unchanged on success; malformed certificates now fail early with `STSE_CERT_UNEXPECTED_SEQUENCE` / `STSE_CERT_INVALID_CERTIFICATE` instead of returning an incorrect size.

# Question (curiosity, not blocking)
`ret` is declared `volatile stse_ReturnCode_t` here (and in a few other API functions). Out of curiosity, is this an intentional **fault-injection** / **glitch-attack countermeasure** (forcing the compiler not to optimize away or cache the return-code checks, so a skipped comparison is harder to induce), or is there another reason? Worth documenting the rationale if so, since it's easy to mistake for dead-code and "clean up".