### PR TITLE
[fix][api] make data storage buffer params const

### DIFF
--- a/api/stse_data_storage.c
+++ b/api/stse_data_storage.c
@@ -144,7 +144,7 @@ stse_ReturnCode_t stse_data_storage_update_data_zone(
     stse_Handle_t *pSTSE,
     PLAT_UI32 zone,
     PLAT_UI16 offset,
-    PLAT_UI8 *pBuffer,
+    const PLAT_UI8 *pBuffer,
     PLAT_UI16 length,
     stse_zone_update_atomicity_t atomicity,
     stse_cmd_protection_t protection) {

--- a/api/stse_data_storage.h
+++ b/api/stse_data_storage.h
@@ -106,7 +106,7 @@ stse_ReturnCode_t stse_data_storage_update_data_zone(
     stse_Handle_t *pSTSE,
     PLAT_UI32 zone,
     PLAT_UI16 offset,
-    PLAT_UI8 *pBuffer,
+    const PLAT_UI8 *pBuffer,
     PLAT_UI16 length,
     stse_zone_update_atomicity_t atomicity,
     stse_cmd_protection_t protection);

--- a/services/stsafea/stsafea_data_partition.c
+++ b/services/stsafea/stsafea_data_partition.c
@@ -345,7 +345,7 @@ stse_ReturnCode_t stsafea_update_data_zone(stse_Handle_t *pSTSE,
                                            PLAT_UI32 zone_index,
                                            stsafea_update_option_t option,
                                            PLAT_UI16 offset,
-                                           PLAT_UI8 *pData,
+                                           const PLAT_UI8 *pData,
                                            PLAT_UI32 data_length,
                                            stse_cmd_protection_t protection) {
 
@@ -376,7 +376,7 @@ stse_ReturnCode_t stsafea_update_data_zone(stse_Handle_t *pSTSE,
     stse_frame_element_allocate_push(&CmdFrame, eOption, STSAFEA_ZONE_ACCESS_OPTION_SIZE, (PLAT_UI8 *)&option);
     stse_frame_element_allocate_push(&CmdFrame, eZoneIndex, STSAFEA_ZONE_INDEX_SIZE, (PLAT_UI8 *)&zone_index);
     stse_frame_element_allocate_push(&CmdFrame, eOffset, STSAFEA_ZONE_OFFSET_SIZE, (PLAT_UI8 *)&offset);
-    stse_frame_element_allocate_push(&CmdFrame, eData, data_length, pData);
+    stse_frame_element_allocate_push(&CmdFrame, eData, data_length, (PLAT_UI8 *)pData);
 
     if (data_length >= stsafea_maximum_frame_length[pSTSE->device_type]) {
         return STSE_SERVICE_FRAME_SIZE_ERROR;

--- a/services/stsafea/stsafea_data_partition.h
+++ b/services/stsafea/stsafea_data_partition.h
@@ -211,7 +211,7 @@ stse_ReturnCode_t stsafea_update_data_zone(stse_Handle_t *pSTSE,
                                            PLAT_UI32 zone_index,
                                            stsafea_update_option_t option,
                                            PLAT_UI16 offset,
-                                           PLAT_UI8 *data,
+                                           const PLAT_UI8 *data,
                                            PLAT_UI32 data_length,
                                            stse_cmd_protection_t protection);
 

--- a/services/stsafel/stsafel_data_partition.c
+++ b/services/stsafel/stsafel_data_partition.c
@@ -69,7 +69,7 @@ stse_ReturnCode_t stsafel_update_data_zone(stse_Handle_t *pSTSE,
                                            PLAT_UI8 zone_index,
                                            stsafel_update_option_t option,
                                            PLAT_UI16 offset,
-                                           PLAT_UI8 *pData,
+                                           const PLAT_UI8 *pData,
                                            PLAT_UI16 data_length,
                                            stse_cmd_protection_t protection) {
     PLAT_UI8 cmd_header = STSAFEL_CMD_UPDATE;
@@ -89,7 +89,7 @@ stse_ReturnCode_t stsafel_update_data_zone(stse_Handle_t *pSTSE,
     stse_frame_element_allocate_push(&CmdFrame, eUpdate_option, sizeof(stsafel_update_option_t), (PLAT_UI8 *)&option);
     stse_frame_element_allocate_push(&CmdFrame, eZone_index, 1, &zone_index);
     stse_frame_element_allocate_push(&CmdFrame, eOffset, 2, (PLAT_UI8 *)&offset);
-    stse_frame_element_allocate_push(&CmdFrame, eData, data_length, pData);
+    stse_frame_element_allocate_push(&CmdFrame, eData, data_length, (PLAT_UI8 *)pData);
 
     /*- Create Rsp frame and populate elements */
     stse_frame_allocate(RspFrame);

--- a/services/stsafel/stsafel_data_partition.h
+++ b/services/stsafel/stsafel_data_partition.h
@@ -99,7 +99,7 @@ stse_ReturnCode_t stsafel_update_data_zone(stse_Handle_t *pSTSE,
                                            PLAT_UI8 zone_index,
                                            stsafel_update_option_t option,
                                            PLAT_UI16 offset,
-                                           PLAT_UI8 *pData,
+                                           const PLAT_UI8 *pData,
                                            PLAT_UI16 data_length,
                                            stse_cmd_protection_t protection);
 


### PR DESCRIPTION
I intentionally left this change out of `CHANGELOG.md` because I don't think it's significant enough to be included.